### PR TITLE
Feature: Multisig

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "@noble/ed25519": "^2.1.0",
     "@scure/bip39": "^1.2.2",
     "@spacemesh/ed25519-bip32": "^0.2.1",
-    "@spacemesh/sm-codec": "^0.6.1",
+    "@spacemesh/sm-codec": "^0.7.1",
     "@tabler/icons-react": "^3.1.0",
     "@tanstack/react-virtual": "^3.3.0",
     "@uidotdev/usehooks": "^2.4.1",

--- a/src/components/FormAmountInput.tsx
+++ b/src/components/FormAmountInput.tsx
@@ -1,4 +1,4 @@
-import { PropsWithChildren, ReactNode, useState } from 'react';
+import { PropsWithChildren, ReactNode, useEffect, useState } from 'react';
 import {
   FieldError,
   FieldErrors,
@@ -8,6 +8,7 @@ import {
   UseFormGetValues,
   UseFormRegisterReturn,
   UseFormSetValue,
+  UseFormWatch,
 } from 'react-hook-form';
 
 import {
@@ -31,6 +32,7 @@ type Props<T extends FieldValues> = PropsWithChildren<{
   isSubmitted?: boolean;
   setValue: UseFormSetValue<T>;
   getValues: UseFormGetValues<T>;
+  watch: UseFormWatch<T>;
 }>;
 
 function FormAmountInput<T extends FieldValues>({
@@ -39,10 +41,41 @@ function FormAmountInput<T extends FieldValues>({
   errors,
   setValue,
   getValues,
+  watch,
   isSubmitted = false,
 }: Props<T>): JSX.Element {
   const [units, setUnits] = useState(CoinUnits.SMH);
   const [displayValue, setDisplayValue] = useState('0');
+  const formVal = watch(register.name as Path<T>);
+
+  useEffect(() => {
+    // Do not re-update in case it is the same value
+    const curSmidges =
+      units === CoinUnits.SMH ? toSmidge(Number(displayValue)) : displayValue;
+    if (!formVal || formVal === curSmidges) {
+      return;
+    }
+
+    if (units === CoinUnits.SMH) {
+      // Update display value and change units if needed
+      if (formVal > 10n ** 7n) {
+        setDisplayValue(toSMH(BigInt(formVal)));
+      } else {
+        setDisplayValue(formVal);
+        setUnits(CoinUnits.Smidge);
+      }
+    }
+    if (units === CoinUnits.Smidge) {
+      // Update display value and change units if needed
+      if (formVal > 10n ** 7n) {
+        setDisplayValue(toSMH(BigInt(formVal)));
+        setUnits(CoinUnits.SMH);
+      } else {
+        setDisplayValue(formVal);
+      }
+    }
+  }, [displayValue, formVal, units]);
+
   const paths = register.name.split('.');
   const error = paths.reduce(
     (acc, next) =>

--- a/src/components/FormAmountInput.tsx
+++ b/src/components/FormAmountInput.tsx
@@ -129,7 +129,12 @@ function FormAmountInput<T extends FieldValues>({
       </FormLabel>
       <Input type="hidden" {...register} />
       <InputGroup>
-        <Input type="number" value={displayValue} onChange={onChange} />
+        <Input
+          type="number"
+          key={`display_input-${register.name}`}
+          value={displayValue}
+          onChange={onChange}
+        />
         <InputRightElement p={0} w={100} justifyContent="end" pr={2}>
           <Text fontSize="xs">{units}</Text>
           <IconButton

--- a/src/components/TxDetails.tsx
+++ b/src/components/TxDetails.tsx
@@ -29,7 +29,7 @@ import {
   formatTxState,
   getDestinationAddress,
   getStatusColor,
-  isSelfSpawnTransaction,
+  isSingleSigSpawnTransaction,
   isSpendTransaction,
 } from '../utils/tx';
 
@@ -109,7 +109,7 @@ const renderTxSpecificData = (tx: Transaction) => {
       </>
     );
   }
-  if (isSelfSpawnTransaction(tx)) {
+  if (isSingleSigSpawnTransaction(tx)) {
     return (
       <Row
         label="PublicKey"

--- a/src/components/TxFileReader.tsx
+++ b/src/components/TxFileReader.tsx
@@ -1,0 +1,85 @@
+import { PropsWithChildren, useRef } from 'react';
+
+import { HexString, isHexString } from '../types/common';
+import { toHexString } from '../utils/hexString';
+
+type TxFileReaderProps = PropsWithChildren<{
+  multiple?: boolean;
+  accept?: string;
+  onRead: (txs: HexString[]) => void;
+  onError: (err: Error) => void;
+}>;
+
+type FileData = { name: string; content: string };
+
+const readFile = (file: File): Promise<FileData> =>
+  new Promise((resolve, reject) => {
+    const fileReader = new FileReader();
+    fileReader.onload = () => {
+      if (fileReader.result) {
+        const content =
+          typeof fileReader.result === 'string'
+            ? fileReader.result
+            : toHexString(fileReader.result, true);
+        resolve({ name: file.name, content });
+      }
+    };
+    fileReader.onerror = reject;
+    fileReader.readAsText(file, 'UTF-8');
+  });
+
+const readAllFiles = (files: File[]): Promise<FileData[]> =>
+  Promise.all(files.map(readFile));
+
+function TxFileReader({
+  multiple = false,
+  accept = undefined,
+  children = null,
+  onRead,
+  onError,
+}: TxFileReaderProps) {
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const handleFileChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const { files } = event.target;
+    if (files) {
+      readAllFiles([...files])
+        .then((datas) => {
+          datas.forEach(({ name, content }) => {
+            if (!isHexString(content)) {
+              throw new Error(`${name} has invalid file format`);
+            }
+          });
+          return datas.map(({ content }) => content);
+        })
+        .then(onRead)
+        .catch(onError);
+    }
+    // eslint-disable-next-line no-param-reassign
+    event.target.value = '';
+  };
+
+  const onClick = () => {
+    if (inputRef.current) {
+      inputRef.current.click();
+    }
+  };
+
+  return (
+    // eslint-disable-next-line max-len
+    // eslint-disable-next-line jsx-a11y/anchor-is-valid, jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions
+    <span style={{ display: 'inline' }} onClick={onClick}>
+      <input
+        ref={inputRef}
+        type="file"
+        onChange={handleFileChange}
+        multiple={multiple}
+        accept={accept}
+        style={{ display: 'none' }}
+      />
+      {children}
+    </span>
+  );
+}
+
+export default TxFileReader;

--- a/src/components/sendTx/ConfirmationModal.tsx
+++ b/src/components/sendTx/ConfirmationModal.tsx
@@ -5,11 +5,17 @@ import { useForm } from 'react-hook-form';
 import {
   Box,
   Button,
+  ButtonGroup,
   Divider,
   Flex,
   FormControl,
   FormErrorMessage,
   FormLabel,
+  IconButton,
+  Menu,
+  MenuButton,
+  MenuItem,
+  MenuList,
   Modal,
   ModalBody,
   ModalCloseButton,
@@ -21,6 +27,7 @@ import {
   Text,
 } from '@chakra-ui/react';
 import { StdPublicKeys } from '@spacemesh/sm-codec';
+import { IconChevronDown } from '@tabler/icons-react';
 
 import { Bech32Address, HexString } from '../../types/common';
 import { SafeKeyWithType } from '../../types/wallet';
@@ -55,6 +62,7 @@ export type ConfirmationData = {
 type ConfirmationModalProps = ConfirmationData & {
   onClose: () => void;
   onSubmit: (signWith: HexString, externalSignature?: HexString) => void;
+  onExport: (signWith: HexString | null, externalSignature?: HexString) => void;
   isOpen: boolean;
   estimatedGas: bigint | null;
 };
@@ -201,6 +209,7 @@ function ConfirmationModal({
   isOpen,
   onClose,
   onSubmit,
+  onExport,
 }: ConfirmationModalProps): JSX.Element {
   const {
     watch,
@@ -228,6 +237,16 @@ function ConfirmationModal({
     reset();
     onSubmit(data.signWith, data.externalSignature);
   });
+
+  const exportSigned = handleSubmit((data) => {
+    reset();
+    onExport(data.signWith, data.externalSignature);
+  });
+
+  const exportUnsigned = () => {
+    reset();
+    onExport(null);
+  };
 
   const isSingleSig = form.templateAddress === StdPublicKeys.SingleSig;
 
@@ -332,14 +351,29 @@ function ConfirmationModal({
           <Button onClick={onClose} ml={2}>
             Back
           </Button>
-          <Button
-            colorScheme="blue"
-            onClick={submit}
-            ml={2}
-            isDisabled={!isSingleSig}
-          >
-            Sign & Publish
-          </Button>
+          <ButtonGroup isAttached>
+            <Button
+              colorScheme="blue"
+              onClick={submit}
+              ml={2}
+              isDisabled={!isSingleSig}
+              mr="1px"
+            >
+              Sign & Publish
+            </Button>
+            <Menu>
+              <MenuButton
+                as={IconButton}
+                icon={<IconChevronDown />}
+                colorScheme="blue"
+                minW={8}
+              />
+              <MenuList>
+                <MenuItem onClick={exportSigned}>Sign & Export</MenuItem>
+                <MenuItem onClick={exportUnsigned}>Export Unsigned</MenuItem>
+              </MenuList>
+            </Menu>
+          </ButtonGroup>
         </ModalFooter>
       </ModalContent>
     </Modal>

--- a/src/components/sendTx/Drain.tsx
+++ b/src/components/sendTx/Drain.tsx
@@ -5,6 +5,7 @@ import {
   UseFormRegister,
   UseFormSetValue,
   UseFormUnregister,
+  UseFormWatch,
 } from 'react-hook-form';
 
 import { FormControl, FormLabel } from '@chakra-ui/react';
@@ -24,6 +25,7 @@ type DrainProps = {
   errors: FieldErrors<FormValues>;
   setValue: UseFormSetValue<FormValues>;
   getValues: UseFormGetValues<FormValues>;
+  watch: UseFormWatch<FormValues>;
   isSubmitted: boolean;
 };
 
@@ -35,6 +37,7 @@ function Drain({
   isSubmitted,
   setValue,
   getValues,
+  watch,
 }: DrainProps): JSX.Element {
   useEffect(
     () => () => {
@@ -90,6 +93,7 @@ function Drain({
         isSubmitted={isSubmitted}
         setValue={setValue}
         getValues={getValues}
+        watch={watch}
       />
     </>
   );

--- a/src/components/sendTx/SendTxModal.tsx
+++ b/src/components/sendTx/SendTxModal.tsx
@@ -1,6 +1,6 @@
 import fileDownload from 'js-file-download';
 import { useEffect, useMemo, useState } from 'react';
-import { Form, useForm } from 'react-hook-form';
+import { FieldPath, FieldPathValue, Form, useForm } from 'react-hook-form';
 
 import {
   Box,
@@ -22,6 +22,7 @@ import {
 import { zodResolver } from '@hookform/resolvers/zod';
 import { O, pipe } from '@mobily/ts-belt';
 import {
+  Codecs,
   DrainArguments,
   MultiSigSpawnArguments as MultiSigSpawnArgumentsTx,
   MultiSigTemplate,
@@ -36,6 +37,8 @@ import {
   VestingSpawnArguments as VestingSpawnArgumentsTx,
   VestingTemplate,
 } from '@spacemesh/sm-codec';
+import { MultiSigPart, SingleSig } from '@spacemesh/sm-codec/lib/codecs';
+import { SpawnArguments } from '@spacemesh/sm-codec/lib/std/singlesig';
 
 import useDataRefresher from '../../hooks/useDataRefresher';
 import {
@@ -44,7 +47,7 @@ import {
 } from '../../hooks/useNetworkSelectors';
 import {
   useEstimateGas,
-  useSignSingleSig,
+  useSignTx,
   useSubmitTx,
 } from '../../hooks/useTxMethods';
 import {
@@ -55,29 +58,32 @@ import useAccountData from '../../store/useAccountData';
 import usePassword from '../../store/usePassword';
 import useWallet from '../../store/useWallet';
 import { HexString } from '../../types/common';
-import { AccountWithAddress, SafeKeyWithType } from '../../types/wallet';
+import { AccountWithAddress } from '../../types/wallet';
 import {
+  extractEligibleKeys,
+  extractRequiredSignatures,
+  isAnyMultiSig,
   isMultiSigAccount,
   isSingleSigAccount,
   isVaultAccount,
   isVestingAccount,
 } from '../../utils/account';
 import { fromBase64 } from '../../utils/base64';
-import { getWords } from '../../utils/bech32';
+import { generateAddress, getWords } from '../../utils/bech32';
 import { fromHexString, toHexString } from '../../utils/hexString';
 import { formatSmidge } from '../../utils/smh';
 import {
   getMethodName,
+  getTemplateMethod,
   getTemplateNameByKey,
   MethodSelectors,
   MultiSigSpawnArguments,
-  SingleSigSpawnArguments,
   TemplateMethodsMap,
-  VestingSpawnArguments,
 } from '../../utils/templates';
 import { computeAddress, getEmptySignature } from '../../utils/wallet';
 import FormInput from '../FormInput';
 import FormSelect from '../FormSelect';
+import TxFileReader from '../TxFileReader';
 
 import ConfirmationModal, { ConfirmationData } from './ConfirmationModal';
 import Drain from './Drain';
@@ -153,7 +159,7 @@ function SendTxModal({ isOpen, onClose }: SendTxModalProps): JSX.Element {
     resolver: zodResolver(FormSchema),
   });
   const selectedMethod = watch('payload.methodSelector');
-  const signTx = useSignSingleSig();
+  const signTx = useSignTx();
   const publishTx = useSubmitTx();
   const { refreshData } = useDataRefresher();
   const estimateGas = useEstimateGas();
@@ -162,6 +168,8 @@ function SendTxModal({ isOpen, onClose }: SendTxModalProps): JSX.Element {
   const confirmationModal = useDisclosure();
   const [txData, setTxData] = useState<null | TxData>(null);
   const [estimatedGas, setEstimatedGas] = useState<null | bigint>(null);
+
+  const [importErrors, setImportErrors] = useState('');
 
   useEffect(() => {
     // Update template address when the current account changes
@@ -220,6 +228,7 @@ function SendTxModal({ isOpen, onClose }: SendTxModalProps): JSX.Element {
 
   const close = () => {
     setTxData(null);
+    setImportErrors('');
     clearErrors();
     onClose();
   };
@@ -280,19 +289,20 @@ function SendTxModal({ isOpen, onClose }: SendTxModalProps): JSX.Element {
                 acc.spawnArguments.PublicKey === args.PublicKey
             )?.displayName || 'external key';
 
-          const eligibleKeys = (wallet?.keychain || []).filter(
-            (kp) => kp.publicKey === args.PublicKey
-          );
-
           setTxData({
             principal,
             form: data,
             encoded,
-            eligibleKeys,
+            eligibleKeys: extractEligibleKeys(
+              currerntAccount,
+              accountsList,
+              wallet?.keychain ?? []
+            ),
             description: `Spawn ${getTemplateNameByKey(
               data.templateAddress
             )} account using ${spawnAccount}`,
             Arguments,
+            isMultiSig: isAnyMultiSig(currerntAccount),
           });
           updateEstimatedGas(encoded, 0);
         }
@@ -318,19 +328,21 @@ function SendTxModal({ isOpen, onClose }: SendTxModalProps): JSX.Element {
             }
           );
 
-          const eligibleKeys = (wallet?.keychain || []).filter((kp) =>
-            args.PublicKeys.includes(kp.publicKey)
-          );
-
           setTxData({
             principal,
             form: data,
             encoded,
-            eligibleKeys,
+            eligibleKeys: extractEligibleKeys(
+              currerntAccount,
+              accountsList,
+              wallet?.keychain ?? []
+            ),
             description: `Spawn ${getTemplateNameByKey(
               data.templateAddress
             )} account: ${currerntAccount.displayName}`,
             Arguments,
+            isMultiSig: isAnyMultiSig(currerntAccount),
+            required: args.Required,
           });
           updateEstimatedGas(encoded, args.Required);
         }
@@ -352,17 +364,20 @@ function SendTxModal({ isOpen, onClose }: SendTxModalProps): JSX.Element {
             }
           );
 
-          const eligibleKeys: SafeKeyWithType[] = []; // TODO
-
           setTxData({
             principal,
             form: data,
             encoded,
-            eligibleKeys,
+            eligibleKeys: extractEligibleKeys(
+              currerntAccount,
+              accountsList,
+              wallet?.keychain ?? []
+            ),
             description: `Spawn ${getTemplateNameByKey(
               data.templateAddress
             )} account: ${currerntAccount.displayName}`,
             Arguments,
+            isMultiSig: isAnyMultiSig(currerntAccount),
           });
           updateEstimatedGas(encoded, 0);
         }
@@ -384,21 +399,20 @@ function SendTxModal({ isOpen, onClose }: SendTxModalProps): JSX.Element {
             }
           );
 
-          const curAcc =
-            currerntAccount as AccountWithAddress<SingleSigSpawnArguments>;
-          const eligibleKeys = (wallet?.keychain || []).filter(
-            (kp) => kp.publicKey === curAcc.spawnArguments.PublicKey
-          );
-
           setTxData({
             principal,
             form: data,
             encoded,
-            eligibleKeys,
+            eligibleKeys: extractEligibleKeys(
+              currerntAccount,
+              accountsList,
+              wallet?.keychain ?? []
+            ),
             description: `Send ${formatSmidge(args.Amount)} to ${
               args.Destination
             }`,
             Arguments,
+            isMultiSig: isAnyMultiSig(currerntAccount),
           });
           updateEstimatedGas(encoded, 0);
         }
@@ -417,25 +431,24 @@ function SendTxModal({ isOpen, onClose }: SendTxModalProps): JSX.Element {
             }
           );
 
-          // TODO
-          const curAcc =
-            currerntAccount as AccountWithAddress<MultiSigSpawnArguments>;
-          const curKeys = curAcc.spawnArguments.PublicKeys;
-          const eligibleKeys = (wallet?.keychain || []).filter((kp) =>
-            curKeys.includes(kp.publicKey)
-          );
-
+          const required = extractRequiredSignatures(currerntAccount);
           setTxData({
             principal,
             form: data,
             encoded,
-            eligibleKeys,
+            eligibleKeys: extractEligibleKeys(
+              currerntAccount,
+              accountsList,
+              wallet?.keychain ?? []
+            ),
             description: `Send ${formatSmidge(args.Amount)} to ${
               args.Destination
             }`,
             Arguments,
+            isMultiSig: isAnyMultiSig(currerntAccount),
+            required,
           });
-          updateEstimatedGas(encoded, curAcc.spawnArguments.Required);
+          updateEstimatedGas(encoded, required);
         }
 
         if (data.templateAddress === StdPublicKeys.Vault) {
@@ -453,19 +466,18 @@ function SendTxModal({ isOpen, onClose }: SendTxModalProps): JSX.Element {
             }
           );
 
-          const curAcc =
-            currerntAccount as AccountWithAddress<SingleSigSpawnArguments>;
-          const eligibleKeys = (wallet?.keychain || []).filter(
-            (kp) => kp.publicKey === curAcc.spawnArguments.PublicKey
-          );
-
           setTxData({
             principal,
             form: data,
             encoded,
-            eligibleKeys,
+            eligibleKeys: extractEligibleKeys(
+              currerntAccount,
+              accountsList,
+              wallet?.keychain ?? []
+            ),
             description: `Spawn ${formatSmidge(args.Amount)}`,
             Arguments,
+            isMultiSig: isAnyMultiSig(currerntAccount),
           });
           updateEstimatedGas(encoded, 0);
         }
@@ -488,24 +500,24 @@ function SendTxModal({ isOpen, onClose }: SendTxModalProps): JSX.Element {
             }
           );
 
-          // TODO
-          const eligibleKeys = (wallet?.keychain || []).filter(
-            (kp) => kp.publicKey === principal
-          );
-
+          const required = extractRequiredSignatures(currerntAccount);
           setTxData({
             principal,
             form: data,
             encoded,
-            eligibleKeys,
+            eligibleKeys: extractEligibleKeys(
+              currerntAccount,
+              accountsList,
+              wallet?.keychain ?? []
+            ),
             description: `Drain ${formatSmidge(args.Amount)} from ${
               args.Vault
             } to ${args.Destination}`,
             Arguments,
+            isMultiSig: isAnyMultiSig(currerntAccount),
+            required,
           });
-          const curAcc =
-            currerntAccount as AccountWithAddress<VestingSpawnArguments>;
-          updateEstimatedGas(encoded, curAcc.spawnArguments.Required);
+          updateEstimatedGas(encoded, required);
         }
         break;
       }
@@ -518,6 +530,11 @@ function SendTxModal({ isOpen, onClose }: SendTxModalProps): JSX.Element {
   });
 
   const sign = async (signWith: HexString, externalSignature?: HexString) => {
+    if (O.isNone(currerntAccount)) {
+      throw new Error(
+        'Cannot sign transaction: please choose an account first.'
+      );
+    }
     if (!txData) {
       throw new Error('Cannot sign unknown transaction');
     }
@@ -528,7 +545,6 @@ function SendTxModal({ isOpen, onClose }: SendTxModalProps): JSX.Element {
       );
     }
 
-    // TODO: Support multisig
     const signature = !externalSignature
       ? await withPassword(
           (password) => signTx(txData.encoded, signWith, password),
@@ -538,7 +554,27 @@ function SendTxModal({ isOpen, onClose }: SendTxModalProps): JSX.Element {
       : fromHexString(externalSignature);
 
     if (signature) {
-      // TODO: Support multisig
+      if (
+        currerntAccount.templateAddress === StdPublicKeys.MultiSig ||
+        currerntAccount.templateAddress === StdPublicKeys.Vesting
+      ) {
+        const keys = (currerntAccount.spawnArguments as MultiSigSpawnArguments)
+          .PublicKeys;
+        const ref = keys.findIndex((k) => k === signWith);
+        const existingSignatures = (txData.signatures as MultiSigPart[]) || [];
+        const sortedSignatures = [
+          ...existingSignatures,
+          {
+            Ref: BigInt(ref),
+            Sig: signature,
+          },
+        ].sort((a, b) => Number(a.Ref - b.Ref));
+        return MultiSigTemplate.methods[0].sign(
+          txData.encoded,
+          sortedSignatures
+        );
+      }
+      // SingleSig, also valid for Vault account
       return SingleSigTemplate.methods[0].sign(txData.encoded, signature);
     }
     return null;
@@ -557,10 +593,8 @@ function SendTxModal({ isOpen, onClose }: SendTxModalProps): JSX.Element {
         'Cannot sign and publish transaction: No Genesis ID, please connect to the network first'
       );
     }
-
     const signedTx = await sign(signWith, externalSignature);
     if (signedTx) {
-      // TODO: Support multisig
       try {
         const txId = await publishTx(signedTx);
         // eslint-disable-next-line no-console
@@ -623,8 +657,265 @@ function SendTxModal({ isOpen, onClose }: SendTxModalProps): JSX.Element {
       : txData.encoded;
 
     if (tx) {
-      fileDownload(toHexString(tx, true), 'transaction.hex', 'text/plain');
+      const hex = toHexString(tx, true);
+      fileDownload(
+        hex,
+        `tx-${signWith ? 'signed' : 'unsigned'}-${hex.slice(-6)}.hex`,
+        'text/plain'
+      );
     }
+  };
+
+  const importTx = async (txs: HexString[]) => {
+    if (O.isNone(currerntAccount)) {
+      throw new Error(
+        'Cannot import a transaction: please choose an account first.'
+      );
+    }
+
+    const headers = txs.map(Codecs.TxHeader.dec);
+    if (!headers[0]) {
+      throw new Error(
+        // eslint-disable-next-line max-len
+        'No valid transactions found. Please choose another transaction file(s).'
+      );
+    }
+    const expectedPrincipal = toHexString(getWords(currerntAccount.address));
+    const validPrincipal = headers.every(
+      (h) => toHexString(h.Principal) === expectedPrincipal
+    );
+
+    if (!validPrincipal) {
+      throw new Error(
+        // eslint-disable-next-line max-len
+        'Cannot import a transaction: one or more transactions belongs to another account'
+      );
+      return;
+    }
+
+    const method = Number(headers[0].MethodSelector) as MethodSelectors;
+    const tpl = getTemplateMethod(currerntAccount.templateAddress, method);
+    const parsed = txs.map((x) => tpl.decode(fromHexString(x)));
+    const rawTx = parsed[0];
+
+    if (!rawTx) {
+      throw new Error('Cannot parse imported transaction');
+    }
+
+    const rawPayload = rawTx.Payload as Parameters<typeof tpl.encode>[1];
+    const withoutSignatures = parsed.map((x) =>
+      tpl.encode(
+        rawTx.Principal,
+        // TODO: TS cannot infer the type properly
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore
+        x.Payload
+      )
+    );
+    if (
+      !withoutSignatures.every(
+        (x) => toHexString(x) === toHexString(withoutSignatures[0] ?? [])
+      )
+    ) {
+      throw new Error('All imported transactions should be the same');
+    }
+
+    const encoded = tpl.encode(
+      getWords(currerntAccount.address),
+      // TODO: TS cannot infer the type of `rawPayload` here
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore
+      rawPayload
+    );
+
+    const convertToFormValues = (tx: typeof rawTx): FormValues => {
+      const templateAddress =
+        currerntAccount.templateAddress as StdTemplateKeys;
+      switch (method) {
+        case MethodSelectors.SelfSpawn: {
+          if (templateAddress === StdPublicKeys.SingleSig) {
+            const args = tx.Payload.Arguments as SpawnArguments;
+            return {
+              templateAddress,
+              nonce: Number(tx.Payload.Nonce),
+              gasPrice: Number(tx.Payload.GasPrice),
+              payload: {
+                methodSelector: method,
+                PublicKey: toHexString(args.PublicKey),
+              },
+            };
+          }
+          if (
+            templateAddress === StdPublicKeys.MultiSig ||
+            templateAddress === StdPublicKeys.Vesting
+          ) {
+            const args = tx.Payload.Arguments as MultiSigSpawnArgumentsTx;
+            return {
+              templateAddress,
+              nonce: Number(tx.Payload.Nonce),
+              gasPrice: Number(tx.Payload.GasPrice),
+              payload: {
+                methodSelector: method,
+                Required: Number(args.Required),
+                PublicKeys: args.PublicKeys.map((x) => toHexString(x)),
+              },
+            };
+          }
+          if (templateAddress === StdPublicKeys.Vault) {
+            const args = tx.Payload.Arguments as VaultSpawnArgumentsTx;
+            return {
+              templateAddress,
+              nonce: Number(tx.Payload.Nonce),
+              gasPrice: Number(tx.Payload.GasPrice),
+              payload: {
+                methodSelector: method,
+                Owner: generateAddress(args.Owner, hrp),
+                TotalAmount: args.TotalAmount.toString(),
+                InitialUnlockAmount: args.InitialUnlockAmount.toString(),
+                VestingStart: Number(args.VestingStart),
+                VestingEnd: Number(args.VestingEnd),
+              },
+            };
+          }
+          throw new Error(
+            `Template ${templateAddress} does not support SelfSpawn transaction`
+          );
+        }
+        case MethodSelectors.Spend: {
+          if (
+            templateAddress === StdPublicKeys.SingleSig ||
+            templateAddress === StdPublicKeys.MultiSig ||
+            templateAddress === StdPublicKeys.Vault
+          ) {
+            const args = tx.Payload.Arguments as SpendArguments;
+            return {
+              templateAddress,
+              nonce: Number(tx.Payload.Nonce),
+              gasPrice: Number(tx.Payload.GasPrice),
+              payload: {
+                methodSelector: method,
+                Amount: args.Amount.toString(),
+                Destination: generateAddress(args.Destination, hrp),
+              },
+            };
+          }
+          throw new Error(
+            `Template ${templateAddress} does not support Spend transaction`
+          );
+        }
+        case MethodSelectors.Drain: {
+          if (templateAddress === StdPublicKeys.Vesting) {
+            const args = tx.Payload.Arguments as DrainArguments;
+            return {
+              templateAddress,
+              nonce: Number(tx.Payload.Nonce),
+              gasPrice: Number(tx.Payload.GasPrice),
+              payload: {
+                methodSelector: method,
+                Vault: generateAddress(args.Vault, hrp),
+                Amount: args.Amount.toString(),
+                Destination: generateAddress(args.Destination, hrp),
+              },
+            };
+          }
+          throw new Error(
+            `Template ${templateAddress} does not support SelfSpawn transaction`
+          );
+        }
+        default: {
+          throw new Error(`Unknown method: ${method}`);
+        }
+      }
+    };
+
+    const extractSignatures = (): undefined | SingleSig | MultiSigPart[] => {
+      // Extract SingleSig
+      if (
+        currerntAccount.templateAddress === StdPublicKeys.SingleSig ||
+        currerntAccount.templateAddress === StdPublicKeys.Vault
+      ) {
+        return parsed.reduce(
+          (acc, next) => next.Signature || acc,
+          undefined as undefined | SingleSig
+        );
+      }
+      // Extract MultiSig parts
+      const sigs = new Set<MultiSigPart>();
+      parsed.forEach((next) => {
+        if (next.Signatures) {
+          next.Signatures.forEach((nextSig) => {
+            sigs.add(nextSig);
+          });
+        }
+      });
+      const result = Array.from(sigs);
+      return result.length > 0 ? result : undefined;
+    };
+    const extractRefs = (
+      signatures: undefined | SingleSig | MultiSigPart[]
+    ) => {
+      if (
+        currerntAccount.templateAddress === StdPublicKeys.SingleSig ||
+        currerntAccount.templateAddress === StdPublicKeys.Vault
+      ) {
+        return undefined;
+      }
+      return (signatures as MultiSigPart[]).map(({ Ref }) => Number(Ref));
+    };
+
+    const form = convertToFormValues(rawTx);
+
+    const required = extractRequiredSignatures(currerntAccount);
+    const signatures = extractSignatures();
+    const refs = extractRefs(signatures);
+    // Set transaction data
+    setTxData({
+      principal: currerntAccount.address,
+      form,
+      encoded,
+      eligibleKeys: extractEligibleKeys(
+        currerntAccount,
+        accountsList,
+        wallet?.keychain ?? [],
+        refs
+      ),
+      description: `Sign and publish ${getTemplateNameByKey(
+        currerntAccount.templateAddress
+      )}.${getMethodName(method)} transaction`,
+      Arguments: rawPayload.Arguments,
+      signatures,
+      isMultiSig: isAnyMultiSig(currerntAccount),
+      required,
+    });
+
+    // Update form values
+    Object.entries(form).forEach(([key, value]) => {
+      if (value === Object) {
+        Object.entries(value).forEach(([k, v]) => {
+          setValue(
+            `${key}.${k}` as FieldPath<FormValues>,
+            v as FieldPathValue<FormValues, FieldPath<FormValues>>
+          );
+        });
+      } else {
+        setValue(key as FieldPath<FormValues>, value);
+      }
+    });
+
+    updateEstimatedGas(encoded, required);
+    confirmationModal.onOpen();
+  };
+
+  const handleImportTx = (txs: HexString[]) => {
+    importTx(txs)
+      .then(() => {
+        setImportErrors('');
+      })
+      .catch(showImportError);
+  };
+
+  const showImportError = (err: Error) => {
+    setImportErrors(err.message);
   };
 
   const renderTemplateSpecificFields = (acc: AccountWithAddress) => {
@@ -744,7 +1035,27 @@ function SendTxModal({ isOpen, onClose }: SendTxModalProps): JSX.Element {
           <ModalOverlay />
           <ModalContent>
             <ModalCloseButton />
-            <ModalHeader pb={0}>Send a transaction</ModalHeader>
+            <ModalHeader pb={0}>
+              Send a transaction
+              <Text fontSize="xs" color="gray.400">
+                Or you can
+                <TxFileReader
+                  multiple
+                  onRead={handleImportTx}
+                  onError={showImportError}
+                >
+                  <Button variant="link" colorScheme="purple" size="xs" p={1}>
+                    import a transaction
+                  </Button>
+                </TxFileReader>
+                from file.
+              </Text>
+              {!!importErrors && (
+                <Text mt={2} mb={2} fontSize="xs" color="red">
+                  {importErrors}
+                </Text>
+              )}
+            </ModalHeader>
             <ModalBody minH={0}>
               {errors.root?.message && (
                 <Text mb={2} color="red">

--- a/src/components/sendTx/SendTxModal.tsx
+++ b/src/components/sendTx/SendTxModal.tsx
@@ -648,6 +648,7 @@ function SendTxModal({ isOpen, onClose }: SendTxModalProps): JSX.Element {
             accounts={accountsList}
             setValue={setValue}
             getValues={getValues}
+            watch={watch}
           />
         );
       }
@@ -670,6 +671,7 @@ function SendTxModal({ isOpen, onClose }: SendTxModalProps): JSX.Element {
             accounts={accountsList}
             setValue={setValue}
             getValues={getValues}
+            watch={watch}
           />
         );
       }
@@ -692,6 +694,7 @@ function SendTxModal({ isOpen, onClose }: SendTxModalProps): JSX.Element {
             accounts={accountsList}
             setValue={setValue}
             getValues={getValues}
+            watch={watch}
           />
         );
       }
@@ -714,6 +717,7 @@ function SendTxModal({ isOpen, onClose }: SendTxModalProps): JSX.Element {
             accounts={accountsList}
             setValue={setValue}
             getValues={getValues}
+            watch={watch}
           />
         );
       }

--- a/src/components/sendTx/Spend.tsx
+++ b/src/components/sendTx/Spend.tsx
@@ -5,6 +5,7 @@ import {
   UseFormRegister,
   UseFormSetValue,
   UseFormUnregister,
+  UseFormWatch,
 } from 'react-hook-form';
 
 import { FormControl, FormLabel } from '@chakra-ui/react';
@@ -23,6 +24,7 @@ type SpendProps = {
   errors: FieldErrors<FormValues>;
   setValue: UseFormSetValue<FormValues>;
   getValues: UseFormGetValues<FormValues>;
+  watch: UseFormWatch<FormValues>;
   isSubmitted: boolean;
 };
 
@@ -33,6 +35,7 @@ function Spend({
   errors,
   setValue,
   getValues,
+  watch,
   isSubmitted,
 }: SpendProps): JSX.Element {
   useEffect(
@@ -67,6 +70,7 @@ function Spend({
         isSubmitted={isSubmitted}
         setValue={setValue}
         getValues={getValues}
+        watch={watch}
       />
     </>
   );

--- a/src/hooks/useTxMethods.ts
+++ b/src/hooks/useTxMethods.ts
@@ -18,7 +18,7 @@ export const useEstimateGas = () => {
   };
 };
 
-export const useSignSingleSig = () => {
+export const useSignTx = () => {
   const { revealSecretKey } = useWallet();
   const genesisID = useCurrentGenesisID();
   return async (

--- a/src/store/useAccountData.ts
+++ b/src/store/useAccountData.ts
@@ -146,7 +146,9 @@ const useAccountData = create<AccountDataStore>((set, get) => ({
         false,
         (acc) =>
           !!acc.transactions.find(
-            (tx) => tx.template.method === MethodSelectors.SelfSpawn
+            (tx) =>
+              tx.template.method === MethodSelectors.SelfSpawn &&
+              tx.state === 'TRANSACTION_STATE_PROCESSED'
           )
       )
     ),

--- a/src/utils/account.ts
+++ b/src/utils/account.ts
@@ -1,8 +1,9 @@
 import { StdPublicKeys } from '@spacemesh/sm-codec';
 
-import { AccountWithAddress } from '../types/wallet';
+import { AccountWithAddress, SafeKeyWithType } from '../types/wallet';
 
 import {
+  AnySpawnArguments,
   MultiSigSpawnArguments,
   SingleSigSpawnArguments,
   VaultSpawnArguments,
@@ -28,3 +29,55 @@ export const isVestingAccount = (
   acc: AccountWithAddress
 ): acc is AccountWithAddress<VestingSpawnArguments> =>
   acc.templateAddress === StdPublicKeys.Vesting;
+
+export const isAnyMultiSig = <T extends AnySpawnArguments>(
+  account: AccountWithAddress<T>
+): boolean =>
+  account.templateAddress === StdPublicKeys.MultiSig ||
+  account.templateAddress === StdPublicKeys.Vesting;
+
+export const extractRequiredSignatures = <T extends AnySpawnArguments>(
+  account: AccountWithAddress<T>
+): 0 | number => {
+  // Zero is a special value for SingleSig
+  if (
+    account.templateAddress === StdPublicKeys.MultiSig ||
+    account.templateAddress === StdPublicKeys.Vesting
+  ) {
+    const mSigAcc = account as AccountWithAddress<MultiSigSpawnArguments>;
+    return mSigAcc.spawnArguments.Required;
+  }
+  return 0;
+};
+
+export const extractEligibleKeys = <T extends AnySpawnArguments>(
+  account: AccountWithAddress<T>,
+  accountList: AccountWithAddress<AnySpawnArguments>[],
+  keychain: SafeKeyWithType[],
+  excludeRefs: number[] = []
+): SafeKeyWithType[] => {
+  if (account.templateAddress === StdPublicKeys.SingleSig) {
+    const typedAcc = account as AccountWithAddress<SingleSigSpawnArguments>;
+    return (keychain || []).filter(
+      (kp) => kp.publicKey === typedAcc.spawnArguments.PublicKey
+    );
+  }
+  if (account.templateAddress === StdPublicKeys.Vault) {
+    const typedAcc = account as AccountWithAddress<VaultSpawnArguments>;
+    const ownerAcc = accountList.find(
+      (acc) => acc.address === typedAcc.spawnArguments.Owner
+    );
+    return ownerAcc ? extractEligibleKeys(ownerAcc, accountList, keychain) : [];
+  }
+  if (
+    account.templateAddress === StdPublicKeys.MultiSig ||
+    account.templateAddress === StdPublicKeys.Vesting
+  ) {
+    const typedAcc = account as AccountWithAddress<MultiSigSpawnArguments>;
+    const keys = typedAcc.spawnArguments.PublicKeys.filter(
+      (k, i) => !excludeRefs.includes(i)
+    );
+    return (keychain || []).filter((kp) => keys.includes(kp.publicKey));
+  }
+  return [];
+};

--- a/src/utils/templates.ts
+++ b/src/utils/templates.ts
@@ -1,10 +1,14 @@
 import { bech32 } from 'bech32';
 
 import {
+  MultiSigTemplate,
+  SingleSigTemplate,
   StdMethods,
   StdPublicKeys,
   StdTemplateKeys,
   TemeplateArgumentsMap,
+  VaultTemplate,
+  VestingTemplate,
 } from '@spacemesh/sm-codec';
 
 import { Bech32Address, HexString } from '../types/common';
@@ -130,4 +134,59 @@ export const convertSpawnArgumentsForEncoding = <T extends StdTemplateKeys>(
   }
 
   throw new Error('Cannot convert spawn arguments: Unknown template key');
+};
+
+export const getTemplateMethod = (
+  templateAddress: HexString,
+  method: number
+) => {
+  const throwUnsupportedMethodError = () => {
+    throw new Error(
+      `Template ${getTemplateNameByKey(
+        templateAddress
+      )} does not supported method ${method}`
+    );
+  };
+
+  switch (templateAddress) {
+    case StdPublicKeys.SingleSig: {
+      if (method === MethodSelectors.SelfSpawn) {
+        return SingleSigTemplate.methods[0];
+      }
+      if (method === MethodSelectors.Spend) {
+        return SingleSigTemplate.methods[16];
+      }
+      return throwUnsupportedMethodError();
+    }
+    case StdPublicKeys.MultiSig: {
+      if (method === MethodSelectors.SelfSpawn) {
+        return MultiSigTemplate.methods[0];
+      }
+      if (method === MethodSelectors.Spend) {
+        return MultiSigTemplate.methods[16];
+      }
+      return throwUnsupportedMethodError();
+    }
+    case StdPublicKeys.Vault: {
+      if (method === MethodSelectors.SelfSpawn) {
+        return VaultTemplate.methods[0];
+      }
+      if (method === MethodSelectors.Spend) {
+        return VaultTemplate.methods[16];
+      }
+      return throwUnsupportedMethodError();
+    }
+    case StdPublicKeys.Vesting: {
+      if (method === MethodSelectors.SelfSpawn) {
+        return VestingTemplate.methods[0];
+      }
+      if (method === MethodSelectors.Drain) {
+        return VestingTemplate.methods[17];
+      }
+      return throwUnsupportedMethodError();
+    }
+    default: {
+      throw new Error(`Unknown template: ${templateAddress}`);
+    }
+  }
 };

--- a/src/utils/tx.ts
+++ b/src/utils/tx.ts
@@ -20,7 +20,7 @@ export enum TxType {
   Spent,
 }
 
-export const isSelfSpawnTransaction = (
+export const isSingleSigSpawnTransaction = (
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   tx: Transaction<any>
 ): tx is ParsedSpawnTransaction =>
@@ -32,7 +32,6 @@ export const isSpendTransaction = (
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   tx: Transaction<any>
 ): tx is ParsedSpendTransaction =>
-  tx.template.name === TemplateName.SingleSig &&
   tx.template.method === StdMethods.Spend &&
   Object.hasOwn(tx.parsed, 'Destination') &&
   Object.hasOwn(tx.parsed, 'Amount');

--- a/yarn.lock
+++ b/yarn.lock
@@ -2279,10 +2279,10 @@
   resolved "https://registry.yarnpkg.com/@spacemesh/ed25519-bip32/-/ed25519-bip32-0.2.1.tgz#f622616060fb477b1fbc5d1292ff21993927a3b2"
   integrity sha512-wwB9FHotFBc1IqYLNZRXt9jZIm7K4gWap4EaotEGeoRLvVJNR/J63TXZBEsHhPrMOWTC2yAcxi6GC47bxsYOhA==
 
-"@spacemesh/sm-codec@^0.6.1":
-  version "0.6.1"
-  resolved "https://registry.yarnpkg.com/@spacemesh/sm-codec/-/sm-codec-0.6.1.tgz#0ccd15c39a8e19f14d2f6b808411861480c06893"
-  integrity sha512-nGsK4oIJcWYFM1IZWe3DpgmnS0Uv4V6zCIQTVNm3piYeYgycpaArCDvwDc2goj1FWZt7MaKX6/r8TY3IL5BDuQ==
+"@spacemesh/sm-codec@^0.7.1":
+  version "0.7.1"
+  resolved "https://registry.yarnpkg.com/@spacemesh/sm-codec/-/sm-codec-0.7.1.tgz#b01377e84d6e71f30d790e468cfbef2659dff486"
+  integrity sha512-7apUG6HEtPOEB8HSGYZ91ep9Xrebjjm6KSKffHKD2ycecMCfkWWhsy74Sd/vfaH0hOVPkRVeZAYrisMZtE+HZw==
   dependencies:
     "@noble/hashes" "^1.4.0"
     scale-ts "^1.6.0"


### PR DESCRIPTION
It supports signing and publishing txs from MultiSig account.

### How to use it
1. Create a MultiSig account on "Manage Keys & Accounts" page
2. Switch to it
3. Click "Send tx"
4. On the next screen click "Sign & Export" (if more than one required signature)
5. After exporting file you can return on the previous screen ("Send tx") and click on "Import transaction" link under the header
6. Import a file, and sign again or sign & publish

### Some notes
- You can send such a semi-signed transactions to other parties
- You can collect signatures in asynchronous way (do not way for other party to sign next), and just import a bunch of files. It will automatically merge signatures.
- Any imported transaction should has the principal of the currently selected account
- All imported files should refer to the same transaction
- Explorer does not support MultiSig txs at the moment, so don't panic if you don't see it there
  - My MultiSig account on Testnet-13: `stest1qqqqqqpw8ejkl2x5s22a9wj0pnk4uku4uktkmls6cu7au` ([see in Explorer](https://testnet-13-explorer.spacemesh.network/accounts/stest1qqqqqqpw8ejkl2x5s22a9wj0pnk4uku4uktkmls6cu7au))
  - Self-spawn tx: `0x7a8000728bb009889fc6874c918d73943f117918d8732f28add93aff12e34bc0`
  - Spend tx 1: `0x822f16193d2a7ae38b511f7013e6ecd517b844c7ca14cb0ea5f7ed7b782fa6bb`
  - Spend tx 2: `0xc7d975b4278f1316faef4836545637f8e69d36b74fb4f8225414d24cc49200f6`

### What is left
- Vaults and Vesting accounts is not tested yet
- Some TX details won't be displayed (e.g. no details for MultiSig SelfSpawn tx, and for any of Vault/Vesting txs)

P.S.
I've also updated [@spacemesh/sm-codec](https://www.npmjs.com/package/@spacemesh/sm-codec) to v.0.7.1