### PR TITLE
Fix: show "Unknown fee" if tx published before got response from API

### DIFF
--- a/src/components/TxListItem.tsx
+++ b/src/components/TxListItem.tsx
@@ -27,6 +27,10 @@ function TxListItem({
   layersPerEpoch,
 }: TxListItemProps): JSX.Element {
   const txBalance = getTxBalance(tx, host);
+  const fee =
+    tx.gas.maxGas && tx.gas.price
+      ? formatSmidge(-1n * BigInt(tx.gas.maxGas) * BigInt(tx.gas.price))
+      : 'Unknown fee';
   return (
     <Card
       mb={2}
@@ -73,7 +77,7 @@ function TxListItem({
               {txBalance !== null && formatSmidge(txBalance)}
             </Text>
             <Text color="gray" fontSize="xx-small" title="Fee" mb="2px">
-              {formatSmidge(-1n * BigInt(tx.gas.maxGas) * BigInt(tx.gas.price))}
+              {fee}
             </Text>
           </Flex>
         </Flex>

--- a/src/components/sendTx/SendTxModal.tsx
+++ b/src/components/sendTx/SendTxModal.tsx
@@ -624,7 +624,7 @@ function SendTxModal({ isOpen, onClose }: SendTxModalProps): JSX.Element {
               bitfield: 0,
             },
             gas: {
-              maxGas: String(estimatedGas),
+              maxGas: estimatedGas ? String(estimatedGas) : '',
               price: String(txData.form.gasPrice),
             },
             template: {


### PR DESCRIPTION
@dioexul found and issue:
When User submits a transaction before got response from EstimateGas endpoint, app crashes with an error.
With this fix in such a case "Unknown fee" will be displayed and later replaced with an actual one.

### How to reproduce / test
1. Prepare the transaction, but before clicking on "Next" button turn off the internet (you can use Throttling feature in developer tools on the network tab).
2. Click "Next" and then click "Sign & Publish"
3. Type the password in BUT don't publish yet
4. Turn on internet (you may switch "No internet" to "Slow 3G" in throttling dropdown)
5. And then click on Publish button quickly (to publish it before EstimateGas API will respond)