### PR TITLE
Tweak: prefill vault arguments for genesis accounts

### DIFF
--- a/src/components/AccountSelection.tsx
+++ b/src/components/AccountSelection.tsx
@@ -37,7 +37,7 @@ function AccountSelection(): JSX.Element {
       >
         Switch
       </MenuButton>
-      <MenuList minWidth={240}>
+      <MenuList minWidth={240} maxW="100vw" maxH="80vh" overflow="auto">
         <MenuOptionGroup
           type="radio"
           value={String(selectedAccount)}

--- a/src/components/CreateAccountModal.tsx
+++ b/src/components/CreateAccountModal.tsx
@@ -172,7 +172,9 @@ function CreateAccountModal({
             </Text>
             <FormAddressSelect
               fieldName="owner"
-              accounts={accounts}
+              accounts={accounts.filter(
+                (acc) => acc.templateAddress === StdPublicKeys.Vesting
+              )}
               register={register}
               unregister={unregister}
               errors={errors}

--- a/src/components/CreateAccountModal.tsx
+++ b/src/components/CreateAccountModal.tsx
@@ -227,17 +227,6 @@ function CreateAccountModal({
               inputProps={{ type: 'number' }}
               register={register('totalAmount', {
                 required: 'Please specify total amount locked in the vault',
-                valueAsNumber: true,
-              })}
-              errors={errors}
-              isSubmitted={isSubmitted}
-            />
-            <FormInput
-              label="Initial unlock amount"
-              inputProps={{ type: 'number' }}
-              register={register('initialUnlockAmount', {
-                required: 'Please specify the initial unlock amount',
-                valueAsNumber: true,
               })}
               errors={errors}
               isSubmitted={isSubmitted}

--- a/src/components/KeyManager.tsx
+++ b/src/components/KeyManager.tsx
@@ -43,6 +43,7 @@ import {
 } from '../types/wallet';
 import { BUTTON_ICON_SIZE } from '../utils/constants';
 import {
+  AnySpawnArguments,
   getTemplateNameByKey,
   MultiSigSpawnArguments,
   SingleSigSpawnArguments,
@@ -150,6 +151,15 @@ function KeyManager({ isOpen, onClose }: KeyManagerProps): JSX.Element {
         throw new Error('Unknown account type');
       }
     }
+  };
+
+  const withoutInitialUnlockAmount = (args: AnySpawnArguments) => {
+    if (Object.hasOwn(args, 'InitialUnlockAmount')) {
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      const { InitialUnlockAmount, ...rest } = args as VaultSpawnArguments;
+      return rest;
+    }
+    return args;
   };
 
   return (
@@ -328,18 +338,18 @@ function KeyManager({ isOpen, onClose }: KeyManagerProps): JSX.Element {
                             </Text>
 
                             <Box color="grey">
-                              {Object.entries(acc.spawnArguments).map(
-                                ([k, v]) => (
-                                  <Box
-                                    key={`${safeKeyForAccount(acc)}_${k}_wtf`}
-                                    mt={1}
-                                    fontSize="xx-small"
-                                    wordBreak="break-all"
-                                  >
-                                    {k}: {JSON.stringify(v)}
-                                  </Box>
-                                )
-                              )}
+                              {Object.entries(
+                                withoutInitialUnlockAmount(acc.spawnArguments)
+                              ).map(([k, v]) => (
+                                <Box
+                                  key={`${safeKeyForAccount(acc)}_${k}_wtf`}
+                                  mt={1}
+                                  fontSize="xx-small"
+                                  wordBreak="break-all"
+                                >
+                                  {k}: {JSON.stringify(v)}
+                                </Box>
+                              ))}
                             </Box>
                           </Box>
                         );

--- a/src/components/sendTx/SendTxModal.tsx
+++ b/src/components/sendTx/SendTxModal.tsx
@@ -1180,7 +1180,8 @@ function SendTxModal({ isOpen, onClose }: SendTxModalProps): JSX.Element {
                     isSubmitted={isSubmitted}
                     // eslint-disable-next-line max-len
                     hint="The number is used only once to ensure each transaction is unique. 
-                    It increments automatically, but can also be set manually if needed."
+                    It increments automatically,
+                    but can also be set manually if needed."
                   />
                 </Box>
               </Flex>

--- a/src/components/sendTx/VaultSpawn.tsx
+++ b/src/components/sendTx/VaultSpawn.tsx
@@ -50,11 +50,6 @@ function VaultSpawn({
         value={String(args.TotalAmount)}
       />
       <FormInputViewOnly
-        label="Initial unlock amount"
-        inputProps={{ type: 'number' }}
-        value={String(args.InitialUnlockAmount)}
-      />
-      <FormInputViewOnly
         label="Vesting Start (layer)"
         inputProps={{ type: 'number' }}
         value={String(args.VestingStart)}

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -20,3 +20,35 @@ export const DEFAULT_EXPLORER_URL = 'https://explorer.spacemesh.io';
 export const BUTTON_ICON_SIZE = 16;
 
 export const MAX_MULTISIG_AMOUNT = 10;
+
+export const GENESIS_VESTING_ACCOUNTS = {
+  sm1qqqqqqpdvm9pwx07d99ajgnuj8rp250u90xt4jczwd873: 2743200000000000n,
+  sm1qqqqqqx4shtr69586rtnx2j69hvsp9yeen0q8asqv7duy: 5867100000000000n,
+  sm1qqqqqqqg5232gg5xytss9z0rwj5pw4k39c9e3ugqt6s9a: 1022800000000000n,
+  sm1qqqqqqx35amk872dx5z3le6rzm56qxfm6fea4qsclrtrz: 409000000000000n,
+  sm1qqqqqq8dp9dd27ym74p5e3c0xjyem6079xvfwfsk2hlwh: 2045400000000000n,
+  sm1qqqqqqxg3ymt0zga3h6vexf2d6ak7n94yamck6qfk98m8: 270600000000000n,
+  sm1qqqqqqygvd32u5g8a6tvccjx38ecmnakw576j0g0dsh9n: 4090900000000000n,
+  sm1qqqqqqqqgh8qhqh3ltv9uq0klm404lwjsf9jdagh7kyj0: 333300000000000n,
+  sm1qqqqqq8upt9xtyt5lclxneqmdpaus6j37ma2ecc4fp5qq: 859100000000000n,
+  sm1qqqqqqrfa0yrzehxujdn7w400afw2e7pv4na2ac8sya0k: 293300000000000n,
+  sm1qqqqqqz2ja3vag3xwqdx9z2mukgdx3qdvqh2jequjn5t2: 1990600000000000n,
+  sm1qqqqqqxehnxnamgm5cqdtuqvg7jnhnsq5ug3s4g3d2xa7: 409100000000000n,
+  sm1qqqqqqz43tzlzqyp695je2tk68a7r707vzxuc0ghj8awp: 4909100000000000n,
+  sm1qqqqqqqm5aejp8saqp0mq7z5tkxw6vfd9v2nu2gekut5s: 191800000000000n,
+  sm1qqqqqqq79464hj2atpy6qv8unnaxnm8aqy7t6ygf4hrgf: 2933540000000000n,
+  sm1qqqqqqz8egxnx83k8kehaqpdjmz3dy88xsgawggmcfxnf: 2933540000000000n,
+  sm1qqqqqqqqyatumnx5e0nqgzt38yq7f5x4vlu5uugeyyst4: 2933540000000000n,
+  sm1qqqqqq85pglqtxzjy63h9edgxnh5uellc95xwsqhlgzd2: 2933540000000000n,
+  sm1qqqqqq93xns99ssc9ctu5jr7ss7ehy55gjut3uq9kfd9c: 2933540000000000n,
+  sm1qqqqqqxf6g4xetjunwkfdrlj0ns88zxzkhfd0dg5wrnul: 3303792000000000n,
+  sm1qqqqqqr7pfnc4e9mgwhvnwwl6fg20hu023f27jqss3545: 455300000000000n,
+  sm1qqqqqqxm7vhlzs8uxse3tjypnma2pkre60fuawclhkryu: 831250000000000n,
+  sm1qqqqqq9ww5yvweyvpnz8lfmavarn9wgjwtphvrslej2hk: 184375000000000n,
+  sm1qqqqqq9mcx6ekgn95gh86pwcvcfyhekzkkfawsqpm2uud: 15000000000000n,
+  sm1qqqqqqxy58hpd7hqdzt97ce3qlqar2j3wrnh4csu2f0wl: 100000000000000n,
+  sm1qqqqqqz85un25dd5gaahjeqgxu46aefq3wsxrpsjttk6u: 500000000000000n,
+  sm1qqqqqqzlqnewes9h04ruzfxny982yf7dunz984q09ej4x: 15688500000000000n,
+};
+export const GENESIS_VESTING_START = 105120;
+export const GENESIS_VESTING_END = 420480;

--- a/src/utils/templates.ts
+++ b/src/utils/templates.ts
@@ -39,8 +39,8 @@ export type VestingSpawnArguments = MultiSigSpawnArguments;
 
 export type VaultSpawnArguments = {
   Owner: HexString;
-  TotalAmount: number;
-  InitialUnlockAmount: number;
+  TotalAmount: string;
+  InitialUnlockAmount: string;
   VestingStart: number;
   VestingEnd: number;
 };


### PR DESCRIPTION
Changes:
- `Initial Unlock Amount` is hidden everywhere
- `Initial Unlock Amount` is set to 1/4 of Total Amount by default (even for non genesis accounts)
- Filtered only Vesting accounts to be presented in the Vault's Owner dropdown,
- When creating a Vault, if User picks Vesting account that is used for Genesis Accounts — all fields will be automatically filled up