### PR TITLE
Make it possible to export and import accounts

### DIFF
--- a/src/components/CreateAccountModal.tsx
+++ b/src/components/CreateAccountModal.tsx
@@ -1,6 +1,5 @@
 import { useEffect } from 'react';
 import { Form, useForm } from 'react-hook-form';
-import { z } from 'zod';
 
 import {
   Button,
@@ -18,8 +17,6 @@ import {
 import { zodResolver } from '@hookform/resolvers/zod';
 import { StdPublicKeys } from '@spacemesh/sm-codec';
 
-import { Bech32AddressSchema } from '../api/schemas/address';
-import { HexStringSchema } from '../api/schemas/common';
 import { useCurrentHRP } from '../hooks/useNetworkSelectors';
 import { useAccountsList } from '../hooks/useWalletSelectors';
 import usePassword from '../store/usePassword';
@@ -30,8 +27,13 @@ import {
   GENESIS_VESTING_START,
 } from '../utils/constants';
 import { noop } from '../utils/func';
-import { AnySpawnArguments, getTemplateNameByKey } from '../utils/templates';
+import { getTemplateNameByKey } from '../utils/templates';
 
+import {
+  extractSpawnArgs,
+  FormSchema,
+  FormValues,
+} from './createAccountSchema';
 import FormAddressSelect from './FormAddressSelect';
 import FormInput from './FormInput';
 import FormKeySelect from './FormKeySelect';
@@ -41,79 +43,6 @@ import FormSelect from './FormSelect';
 type CreateAccountModalProps = {
   isOpen: boolean;
   onClose: () => void;
-};
-
-const DisplayNameSchema = z.string().min(2);
-
-const SingleSigSchema = z.object({
-  displayName: DisplayNameSchema,
-  templateAddress: z.literal(StdPublicKeys.SingleSig),
-  publicKey: HexStringSchema,
-});
-
-const MultiSigSchema = z.object({
-  displayName: DisplayNameSchema,
-  templateAddress: z.literal(StdPublicKeys.MultiSig),
-  required: z.number().min(0).max(10),
-  publicKeys: z
-    .array(HexStringSchema)
-    .min(1, 'MultiSig account requires at least two parties'),
-});
-
-const VaultSchema = z.object({
-  displayName: DisplayNameSchema,
-  templateAddress: z.literal(StdPublicKeys.Vault),
-  owner: Bech32AddressSchema,
-  totalAmount: z.string().min(0),
-  initialUnlockAmount: z.string().min(0),
-  vestingStart: z.number().min(0),
-  vestingEnd: z.number().min(0),
-});
-
-const VestingSchema = z.object({
-  displayName: DisplayNameSchema,
-  templateAddress: z.literal(StdPublicKeys.Vesting),
-  required: z.number().min(0).max(10),
-  publicKeys: z
-    .array(HexStringSchema)
-    .min(1, 'Vesting account requires at least two parties'),
-});
-
-const FormSchema = z.discriminatedUnion('templateAddress', [
-  SingleSigSchema,
-  MultiSigSchema,
-  VaultSchema,
-  VestingSchema,
-]);
-
-type FormValues = z.infer<typeof FormSchema>;
-
-const extractSpawnArgs = (data: FormValues): AnySpawnArguments => {
-  let args;
-  args = SingleSigSchema.safeParse(data);
-  if (args.success) {
-    return { PublicKey: args.data.publicKey };
-  }
-  args = MultiSigSchema.safeParse(data);
-  if (args.success) {
-    return { Required: args.data.required, PublicKeys: args.data.publicKeys };
-  }
-  args = VestingSchema.safeParse(data);
-  if (args.success) {
-    return { Required: args.data.required, PublicKeys: args.data.publicKeys };
-  }
-  args = VaultSchema.safeParse(data);
-  if (args.success) {
-    return {
-      Owner: args.data.owner,
-      TotalAmount: args.data.totalAmount,
-      InitialUnlockAmount: args.data.initialUnlockAmount,
-      VestingStart: args.data.vestingStart,
-      VestingEnd: args.data.vestingEnd,
-    };
-  }
-
-  throw new Error('Cannot get required inputs to create an account');
 };
 
 function CreateAccountModal({

--- a/src/components/CreateAccountModal.tsx
+++ b/src/components/CreateAccountModal.tsx
@@ -116,7 +116,7 @@ function CreateAccountModal({
           extractSpawnArgs(data),
           password
         ),
-      'Creating a new Account',
+      'Create a new Account',
       // eslint-disable-next-line max-len
       `Please enter the password to create the new account "${
         data.displayName

--- a/src/components/CreateKeyPairModal.tsx
+++ b/src/components/CreateKeyPairModal.tsx
@@ -45,7 +45,7 @@ function CreateKeyPairModal({
   const submit = handleSubmit(async ({ displayName, path }) => {
     const success = await withPassword(
       (password) => createKeyPair(displayName, path, password),
-      'Creating a new Key Pair',
+      'Create a new Key Pair',
       // eslint-disable-next-line max-len
       `Please enter the password to create the new key pair "${displayName}" with path "${path}"`
     );

--- a/src/components/ImportAccountModal.tsx
+++ b/src/components/ImportAccountModal.tsx
@@ -1,0 +1,223 @@
+import { useEffect, useRef, useState } from 'react';
+
+import {
+  Button,
+  Card,
+  CardBody,
+  FormControl,
+  FormLabel,
+  Input,
+  Modal,
+  ModalBody,
+  ModalCloseButton,
+  ModalContent,
+  ModalFooter,
+  ModalHeader,
+  ModalOverlay,
+  Text,
+} from '@chakra-ui/react';
+import { StdTemplateKeys } from '@spacemesh/sm-codec';
+
+import usePassword from '../store/usePassword';
+import useWallet from '../store/useWallet';
+import { Account, AccountWithAddress } from '../types/wallet';
+import { isAnyAccount } from '../utils/account';
+import { AnySpawnArguments, getTemplateNameByKey } from '../utils/templates';
+
+type ImportAccountModalProps = {
+  isOpen: boolean;
+  onClose: () => void;
+  accounts: AccountWithAddress<AnySpawnArguments>[];
+};
+
+function ImportAccountModal({
+  isOpen,
+  onClose,
+  accounts,
+}: ImportAccountModalProps): JSX.Element {
+  const { createAccount } = useWallet();
+  const { withPassword } = usePassword();
+
+  const inputRef = useRef<HTMLInputElement>(null);
+  const [displayName, setDisplayName] = useState('');
+  const [isSubmitted, setIsSubmitted] = useState(false);
+  const [accountData, setAccountData] =
+    useState<Account<AnySpawnArguments> | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!displayName && accountData?.displayName) {
+      setDisplayName(accountData.displayName);
+    }
+    if (isSubmitted) {
+      return;
+    }
+    if (accountData) {
+      const dataConflict = accounts.find(
+        (acc) =>
+          acc.templateAddress === accountData.templateAddress &&
+          JSON.stringify(acc.spawnArguments) ===
+            JSON.stringify(accountData.spawnArguments)
+      );
+      if (dataConflict) {
+        setError(
+          // eslint-disable-next-line max-len
+          'You already have this account in the wallet. No need to import it once again.'
+        );
+        return;
+      }
+    }
+    const nameConflict = accounts.find(
+      (acc) => acc.displayName === displayName
+    );
+    if (nameConflict) {
+      setError(
+        // eslint-disable-next-line max-len
+        `You have account with such a name in the wallet. Please consider picking another display name`
+      );
+      return;
+    }
+    setError(null);
+  }, [displayName, accounts, accountData, isSubmitted]);
+
+  const close = () => {
+    if (inputRef.current) {
+      inputRef.current.value = '';
+    }
+    setIsSubmitted(false);
+    setError(null);
+    setAccountData(null);
+    setDisplayName('');
+    onClose();
+  };
+
+  const readAccountFile = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+    if (!file) {
+      return;
+    }
+    setError(null);
+
+    const reader = new FileReader();
+    reader.onload = () => {
+      if (inputRef.current) {
+        inputRef.current.value = '';
+      }
+      if (typeof reader.result !== 'string') {
+        setError('Failed to read file');
+        return;
+      }
+      try {
+        const newAccount = JSON.parse(reader.result as string);
+        if (isAnyAccount(newAccount)) {
+          if (!displayName) {
+            setDisplayName(newAccount?.displayName ?? '');
+          }
+          setAccountData({ ...newAccount, displayName });
+        } else {
+          setError(`Cannot parse the account`);
+        }
+      } catch (err) {
+        setError(`Cannot parse the file: ${err}`);
+      }
+    };
+    reader.readAsText(file);
+  };
+
+  const submit = () => {
+    if (accountData) {
+      setIsSubmitted(true);
+      withPassword(
+        (password) =>
+          createAccount(
+            displayName,
+            accountData.templateAddress as StdTemplateKeys,
+            accountData.spawnArguments,
+            password
+          ),
+        'Creating a new Account',
+        // eslint-disable-next-line max-len
+        `Please enter the password to create the new account "${displayName}" of type "${getTemplateNameByKey(
+          accountData.templateAddress
+        )}"`
+      )
+        .then((x) => x && close())
+        .catch((err) => {
+          setError(`Failed to open wallet file:\n${err}`);
+          setIsSubmitted(false);
+        });
+    }
+  };
+
+  return (
+    <Modal isOpen={isOpen} onClose={close} isCentered>
+      <ModalOverlay />
+      <ModalContent>
+        <ModalCloseButton />
+        <ModalHeader>Import Account</ModalHeader>
+        <ModalBody textAlign="center">
+          <Text mb={4}>Please select the account file to import.</Text>
+          <Input
+            ref={inputRef}
+            type="file"
+            display="none"
+            accept=".account"
+            onChange={readAccountFile}
+          />
+          <Button
+            size="lg"
+            onClick={() => inputRef.current?.click()}
+            variant="solid"
+            colorScheme="green"
+            mb={4}
+          >
+            Select account file
+          </Button>
+          <FormControl mb={4}>
+            <FormLabel fontSize="sm" mb={0}>
+              Please set the display name for imported account:
+            </FormLabel>
+            <Input
+              type="text"
+              onChange={(e) => setDisplayName(e.target.value)}
+              value={displayName}
+            />
+          </FormControl>
+          {accountData && (
+            <Card variant="outline">
+              <CardBody p={2} overflow="auto">
+                <Text as="pre" fontSize="xx-small" textAlign="left">
+                  Template: {getTemplateNameByKey(accountData.templateAddress)}
+                  {'\n\n'}
+                  {Object.entries(accountData.spawnArguments).map(
+                    ([k, v], i) =>
+                      `${i !== 0 ? '\n' : ''}${k}: ${
+                        v instanceof Array ? `\n${v.join('\n')}` : v
+                      }\n`
+                  )}
+                </Text>
+              </CardBody>
+            </Card>
+          )}
+          {error && (
+            <Text mt={4} color="red">
+              {error}
+            </Text>
+          )}
+        </ModalBody>
+        <ModalFooter>
+          <Button
+            colorScheme="blue"
+            onClick={submit}
+            ml={2}
+            isDisabled={!!error}
+          >
+            Import
+          </Button>
+        </ModalFooter>
+      </ModalContent>
+    </Modal>
+  );
+}
+
+export default ImportAccountModal;

--- a/src/components/ImportAccountModal.tsx
+++ b/src/components/ImportAccountModal.tsx
@@ -135,7 +135,7 @@ function ImportAccountModal({
             accountData.spawnArguments,
             password
           ),
-        'Creating a new Account',
+        'Import Account',
         // eslint-disable-next-line max-len
         `Please enter the password to create the new account "${displayName}" of type "${getTemplateNameByKey(
           accountData.templateAddress

--- a/src/components/KeyManager.tsx
+++ b/src/components/KeyManager.tsx
@@ -1,3 +1,4 @@
+import fileDownload from 'js-file-download';
 import { useState } from 'react';
 
 import {
@@ -55,6 +56,7 @@ import CopyButton from './CopyButton';
 import CreateAccountModal from './CreateAccountModal';
 import CreateKeyPairModal from './CreateKeyPairModal';
 import ExplorerButton from './ExplorerButton';
+import ImportAccountModal from './ImportAccountModal';
 import ImportKeyPairModal from './ImportKeyPairModal';
 import RevealSecretKeyModal from './RevealSecretKeyModal';
 
@@ -105,6 +107,7 @@ function KeyManager({ isOpen, onClose }: KeyManagerProps): JSX.Element {
   const importKeyPairModal = useDisclosure();
   const revealSecretKeyModal = useDisclosure();
   const createAccountModal = useDisclosure();
+  const importAccountModal = useDisclosure();
 
   const closeHandler = () => {
     onClose();
@@ -129,6 +132,13 @@ function KeyManager({ isOpen, onClose }: KeyManagerProps): JSX.Element {
       revealSecretKeyModal.onOpen();
     }
   };
+
+  const exportAccount = (acc: AccountWithAddress) =>
+    fileDownload(
+      JSON.stringify(acc, null, 2),
+      `${acc.address}.account`,
+      'text/plain'
+    );
 
   const getKeysByAccount = (acc: AccountWithAddress) => {
     switch (acc.templateAddress) {
@@ -272,6 +282,12 @@ function KeyManager({ isOpen, onClose }: KeyManagerProps): JSX.Element {
                           Create new account
                         </Text>
                       </Button>
+                      <Button onClick={importAccountModal.onOpen}>
+                        <IconFileImport size={BUTTON_ICON_SIZE} />
+                        <Text as="span" ml={1}>
+                          Import account
+                        </Text>
+                      </Button>
                     </ButtonGroup>
                     <Box flex={1}>
                       {accounts.map((acc) => {
@@ -284,6 +300,22 @@ function KeyManager({ isOpen, onClose }: KeyManagerProps): JSX.Element {
                             backgroundColor="blackAlpha.300"
                             borderRadius="md"
                           >
+                            <Button
+                              size="xx-small"
+                              p={1}
+                              fontSize="xx-small"
+                              fontWeight="normal"
+                              float="right"
+                              display="flex"
+                              alignItems="center"
+                              borderRadius="sm"
+                              textTransform="uppercase"
+                              gap={1}
+                              onClick={() => exportAccount(acc)}
+                            >
+                              <IconKey size={12} />
+                              Export account
+                            </Button>
                             <Text fontSize="md">
                               <strong>{acc.displayName}</strong>
                               <Badge
@@ -380,6 +412,11 @@ function KeyManager({ isOpen, onClose }: KeyManagerProps): JSX.Element {
       <CreateAccountModal
         isOpen={createAccountModal.isOpen}
         onClose={createAccountModal.onClose}
+      />
+      <ImportAccountModal
+        accounts={accounts}
+        isOpen={importAccountModal.isOpen}
+        onClose={importAccountModal.onClose}
       />
     </>
   );

--- a/src/components/createAccountSchema.tsx
+++ b/src/components/createAccountSchema.tsx
@@ -1,0 +1,73 @@
+import { z } from 'zod';
+
+import { StdPublicKeys } from '@spacemesh/sm-codec';
+
+import { Bech32AddressSchema } from '../api/schemas/address';
+import { HexStringSchema } from '../api/schemas/common';
+import { AnySpawnArguments } from '../utils/templates';
+
+const DisplayNameSchema = z.string().min(2);
+const SingleSigSchema = z.object({
+  displayName: DisplayNameSchema,
+  templateAddress: z.literal(StdPublicKeys.SingleSig),
+  publicKey: HexStringSchema,
+});
+const MultiSigSchema = z.object({
+  displayName: DisplayNameSchema,
+  templateAddress: z.literal(StdPublicKeys.MultiSig),
+  required: z.number().min(0).max(10),
+  publicKeys: z
+    .array(HexStringSchema)
+    .min(1, 'MultiSig account requires at least two parties'),
+});
+const VaultSchema = z.object({
+  displayName: DisplayNameSchema,
+  templateAddress: z.literal(StdPublicKeys.Vault),
+  owner: Bech32AddressSchema,
+  totalAmount: z.string().min(0),
+  initialUnlockAmount: z.string().min(0),
+  vestingStart: z.number().min(0),
+  vestingEnd: z.number().min(0),
+});
+const VestingSchema = z.object({
+  displayName: DisplayNameSchema,
+  templateAddress: z.literal(StdPublicKeys.Vesting),
+  required: z.number().min(0).max(10),
+  publicKeys: z
+    .array(HexStringSchema)
+    .min(1, 'Vesting account requires at least two parties'),
+});
+export const FormSchema = z.discriminatedUnion('templateAddress', [
+  SingleSigSchema,
+  MultiSigSchema,
+  VaultSchema,
+  VestingSchema,
+]);
+export type FormValues = z.infer<typeof FormSchema>;
+export const extractSpawnArgs = (data: FormValues): AnySpawnArguments => {
+  let args;
+  args = SingleSigSchema.safeParse(data);
+  if (args.success) {
+    return { PublicKey: args.data.publicKey };
+  }
+  args = MultiSigSchema.safeParse(data);
+  if (args.success) {
+    return { Required: args.data.required, PublicKeys: args.data.publicKeys };
+  }
+  args = VestingSchema.safeParse(data);
+  if (args.success) {
+    return { Required: args.data.required, PublicKeys: args.data.publicKeys };
+  }
+  args = VaultSchema.safeParse(data);
+  if (args.success) {
+    return {
+      Owner: args.data.owner,
+      TotalAmount: args.data.totalAmount,
+      InitialUnlockAmount: args.data.initialUnlockAmount,
+      VestingStart: args.data.vestingStart,
+      VestingEnd: args.data.vestingEnd,
+    };
+  }
+
+  throw new Error('Cannot get required inputs to create an account');
+};

--- a/src/screens/welcome/ImportScreen.tsx
+++ b/src/screens/welcome/ImportScreen.tsx
@@ -99,7 +99,6 @@ function ImportScreen(): JSX.Element {
               ref={inputRef}
               display="none"
               type="file"
-              size="lg"
               accept=".json"
               onChange={readFile}
             />

--- a/src/utils/account.ts
+++ b/src/utils/account.ts
@@ -36,6 +36,15 @@ export const isAnyMultiSig = <T extends AnySpawnArguments>(
   account.templateAddress === StdPublicKeys.MultiSig ||
   account.templateAddress === StdPublicKeys.Vesting;
 
+export const isAnyAccount = (
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  account: any
+): account is AccountWithAddress<AnySpawnArguments> =>
+  isSingleSigAccount(account) ||
+  isMultiSigAccount(account) ||
+  isVestingAccount(account) ||
+  isVaultAccount(account);
+
 export const extractRequiredSignatures = <T extends AnySpawnArguments>(
   account: AccountWithAddress<T>
 ): 0 | number => {


### PR DESCRIPTION
This PR adds:
- "Export account" button in the right-top corner to every account on the "Manage Keys & Accounts" page,
   <img width="517" alt="image" src="https://github.com/user-attachments/assets/dce6a4a5-1a51-4e73-924d-7653ed48fada">
- "Import account" button, which opens the modal to confirm account and give it an unique display name:
   <img width="366" alt="image" src="https://github.com/user-attachments/assets/194a6be8-a6f5-4e87-8904-7b3056f56f3c">