### PR TITLE
Tweak GUI

### DIFF
--- a/src/components/FormInput.tsx
+++ b/src/components/FormInput.tsx
@@ -24,7 +24,7 @@ type Props<T extends FieldValues> = PropsWithChildren<{
   isSubmitted?: boolean;
   inputAddon?: ReactNode;
   inputProps?: InputProps;
-  hint?: string;
+  hint?: ReactNode;
 }>;
 
 function FormInput<T extends FieldValues>({

--- a/src/components/sendTx/SendTxModal.tsx
+++ b/src/components/sendTx/SendTxModal.tsx
@@ -1153,13 +1153,24 @@ function SendTxModal({ isOpen, onClose }: SendTxModalProps): JSX.Element {
                     errors={errors}
                     isSubmitted={isSubmitted}
                     inputAddon={
-                      <InputRightElement mr={2}>
-                        <Text fontSize="xs">Smidge</Text>
+                      <InputRightElement w="auto" pr={2}>
+                        <Text fontSize="xs">Smidge per unit</Text>
                       </InputRightElement>
                     }
-                    // eslint-disable-next-line max-len
-                    hint="How much to pay for gas: During high network traffic, 
-                    transactions with higher gas fees are prioritized."
+                    hint={
+                      <>
+                        <Text mb={2}>
+                          <strong>How much to pay per gas unit</strong>
+                          <br />
+                          During high network traffic, transactions with higher
+                          gas prices are prioritized.
+                        </Text>
+                        <Text>
+                          Example: transaction costs 25,000 gas units, gas price
+                          is 2 smidges, the total fee will be 50,000 smidges.
+                        </Text>
+                      </>
+                    }
                   />
                 </Box>
                 <Box ml={2} w="50%">
@@ -1178,10 +1189,17 @@ function SendTxModal({ isOpen, onClose }: SendTxModalProps): JSX.Element {
                     })}
                     errors={errors}
                     isSubmitted={isSubmitted}
-                    // eslint-disable-next-line max-len
-                    hint="The number is used only once to ensure each transaction is unique. 
-                    It increments automatically,
-                    but can also be set manually if needed."
+                    hint={
+                      <Text>
+                        <strong>The transaction counter</strong>
+                        <br />
+                        The number is used only to ensure each transaction is
+                        unique.
+                        <br />
+                        It increments automatically, but can be set manually if
+                        needed.
+                      </Text>
+                    }
                   />
                 </Box>
               </Flex>

--- a/src/store/useAccountData.ts
+++ b/src/store/useAccountData.ts
@@ -68,6 +68,11 @@ const getAccountRewards = (net: NetworkState, address: Bech32Address) =>
 const getAccountTransactions = (net: NetworkState, address: Bech32Address) =>
   (net.txIds?.[address] || [])
     .map((txId) => net.transactions?.[txId])
+    .sort((a, b) => {
+      if (!a?.layer) return 1;
+      if (!b?.layer) return -1;
+      return a.layer - b.layer;
+    })
     .filter(Boolean) as Transaction[];
 
 // Store


### PR DESCRIPTION
1. Redesigned items in the transaction log with @pigmej assistance
   <img width="600" alt="image" src="https://github.com/user-attachments/assets/193fe2ce-75b7-4f4f-98a5-25de3d18fee0">

2. Improved hints for Gas Price and Nonce and corrected units (`Smidge -> Smidge per unit`)
    <img width="600" alt="image" src="https://github.com/user-attachments/assets/fbeefe7c-92db-431c-9bb2-17b631f2df52">
    <img width="600" alt="image" src="https://github.com/user-attachments/assets/189fa609-5d5e-4c12-b648-ccee6429241d">