### PR TITLE
Tweak Ledger flow

### DIFF
--- a/src/components/HardwareWalletConnect.tsx
+++ b/src/components/HardwareWalletConnect.tsx
@@ -158,6 +158,7 @@ function DeviceApprovalModal() {
     <Modal isOpen={modalApproval.isOpen} onClose={noop} isCentered>
       <ModalOverlay />
       <ModalContent>
+        <ModalCloseButton />
         <ModalHeader>Sign Transaction on Ledger Device</ModalHeader>
         <ModalBody minH={0} pb={6}>
           <Text>
@@ -166,6 +167,47 @@ function DeviceApprovalModal() {
             <Image src={ledgerLogo} width={100} mt={6} />
           </Text>
         </ModalBody>
+      </ModalContent>
+    </Modal>
+  );
+}
+
+function WrongDeviceModal() {
+  const { modalWrongDevice, resetDevice } = useHardwareWallet();
+  const disconnectAndClose = () => {
+    resetDevice();
+    modalWrongDevice.onClose();
+  };
+
+  return (
+    <Modal
+      isOpen={modalWrongDevice.isOpen}
+      onClose={modalWrongDevice.onClose}
+      isCentered
+    >
+      <ModalOverlay />
+      <ModalContent>
+        <ModalHeader>Wrong Ledger device is connected</ModalHeader>
+        <ModalBody minH={0} pb={6}>
+          <Text>
+            Connected Ledger device does not have required public key to sign
+            this transaction. Please, connect the proper Ledger device and try
+            again.
+          </Text>
+        </ModalBody>
+        <ModalFooter>
+          <Button
+            variant="outline"
+            colorScheme="red"
+            onClick={disconnectAndClose}
+          >
+            Disconnect
+          </Button>
+          <Spacer />
+          <Button colorScheme="blue" onClick={modalWrongDevice.onClose}>
+            OK
+          </Button>
+        </ModalFooter>
       </ModalContent>
     </Modal>
   );
@@ -206,6 +248,7 @@ function Connected({ device }: { device: LedgerDevice }) {
       />
       <DeviceReconnectModal />
       <DeviceApprovalModal />
+      <WrongDeviceModal />
     </>
   );
 }

--- a/src/components/ImportKeyFromLedgerModal.tsx
+++ b/src/components/ImportKeyFromLedgerModal.tsx
@@ -17,6 +17,7 @@ import { StdPublicKeys } from '@spacemesh/sm-codec';
 import useHardwareWallet from '../store/useHardwareWallet';
 import usePassword from '../store/usePassword';
 import useWallet from '../store/useWallet';
+import { KeyPairType } from '../types/wallet';
 import Bip32KeyDerivation from '../utils/bip32';
 
 import FormInput from './FormInput';
@@ -119,7 +120,11 @@ function ImportKeyFromLedgerModal({
               register={register('path', {
                 required: 'Derivation path is required',
                 value: Bip32KeyDerivation.createPath(
-                  (wallet?.keychain || []).length
+                  (
+                    wallet?.keychain.filter(
+                      (x) => x.type === KeyPairType.Hardware
+                    ) || []
+                  ).length
                 ),
                 validate: (value) => {
                   const valid = Bip32KeyDerivation.isValidPath(value);

--- a/src/components/ImportKeyFromLedgerModal.tsx
+++ b/src/components/ImportKeyFromLedgerModal.tsx
@@ -17,7 +17,6 @@ import { StdPublicKeys } from '@spacemesh/sm-codec';
 import useHardwareWallet from '../store/useHardwareWallet';
 import usePassword from '../store/usePassword';
 import useWallet from '../store/useWallet';
-import { KeyPairType } from '../types/wallet';
 import Bip32KeyDerivation from '../utils/bip32';
 
 import FormInput from './FormInput';
@@ -37,7 +36,7 @@ function ImportKeyFromLedgerModal({
   isOpen,
   onClose,
 }: ImportKeyFromLedgerModalProps): JSX.Element {
-  const { addForeignKey, createAccount, wallet } = useWallet();
+  const { addForeignKey, createAccount } = useWallet();
   const { withPassword } = usePassword();
   const { checkDeviceConnection, connectedDevice, modalConnect } =
     useHardwareWallet();
@@ -119,13 +118,7 @@ function ImportKeyFromLedgerModal({
               label="Derivation Path"
               register={register('path', {
                 required: 'Derivation path is required',
-                value: Bip32KeyDerivation.createPath(
-                  (
-                    wallet?.keychain.filter(
-                      (x) => x.type === KeyPairType.Hardware
-                    ) || []
-                  ).length
-                ),
+                value: Bip32KeyDerivation.createPath(0),
                 validate: (value) => {
                   const valid = Bip32KeyDerivation.isValidPath(value);
                   if (!valid) {

--- a/src/components/sendTx/SendTxModal.tsx
+++ b/src/components/sendTx/SendTxModal.tsx
@@ -126,7 +126,8 @@ function SendTxModal({ isOpen, onClose }: SendTxModalProps): JSX.Element {
   const { wallet } = useWallet();
   const { withPassword } = usePassword();
   const { isSpawnedAccount, getAccountData } = useAccountData();
-  const { checkDeviceConnection, connectedDevice } = useHardwareWallet();
+  const { checkDeviceConnection, connectedDevice, modalWrongDevice } =
+    useHardwareWallet();
   const hrp = useCurrentHRP();
   const genesisID = useCurrentGenesisID();
   const currerntAccount = useCurrentAccount(hrp);
@@ -579,6 +580,13 @@ function SendTxModal({ isOpen, onClose }: SendTxModalProps): JSX.Element {
       const keyToUse = wallet.keychain.find((k) => k.publicKey === signWith);
       if (isForeignKey(keyToUse) && keyToUse.origin === KeyOrigin.Ledger) {
         if (!(await checkDeviceConnection()) || !connectedDevice) {
+          return null;
+        }
+        const ledgerKey = await connectedDevice.actions.getPubKey(
+          keyToUse.path
+        );
+        if (ledgerKey !== keyToUse.publicKey) {
+          modalWrongDevice.onOpen();
           return null;
         }
         return connectedDevice.actions

--- a/src/store/useHardwareWallet.ts
+++ b/src/store/useHardwareWallet.ts
@@ -65,6 +65,7 @@ export type UseHardwareWalletHook = {
   modalConnect: UseDisclosureReturn;
   modalReconnect: UseDisclosureReturn;
   modalApproval: UseDisclosureReturn;
+  modalWrongDevice: UseDisclosureReturn;
   // Actions
   connectDevice: (transport: LedgerTransports) => void;
   reconnectDevice: () => Promise<void>;
@@ -94,6 +95,7 @@ const useHardwareWallet = (): UseHardwareWalletHook => {
   const modalConnect = useDisclosure({ id: 'connectDevice' });
   const modalReconnect = useDisclosure({ id: 'reconnectDevice' });
   const modalApproval = useDisclosure({ id: 'approvalDevice' });
+  const modalWrongDevice = useDisclosure({ id: 'wrongDevice' });
 
   const handleLedgerError = (e: Error) => {
     modalReconnect.onOpen();
@@ -192,6 +194,7 @@ const useHardwareWallet = (): UseHardwareWalletHook => {
     modalConnect,
     modalReconnect,
     modalApproval,
+    modalWrongDevice,
     // Actions
     connectDevice,
     reconnectDevice,
@@ -210,6 +213,7 @@ export default singletonHook(
     modalConnect: getDisclosureDefaults(),
     modalReconnect: getDisclosureDefaults(),
     modalApproval: getDisclosureDefaults(),
+    modalWrongDevice: getDisclosureDefaults(),
     // Actions
     connectDevice: noop,
     reconnectDevice: Promise.resolve,


### PR DESCRIPTION
It closes #41:
1. Use `0/0/0` as default derivation path for importing from Ledger device (will be improved later within https://github.com/spacemeshos/smapp-lite/issues/52)
2. Show "Wrong Ledger device" modal in case User trying to sign transaction with Ledger, while connected Ledger device does not contain the corresponding key