### PR TITLE
Lock on unfocused app after 2 min + 30 seconds countdown

### DIFF
--- a/src/components/IdleAlert.tsx
+++ b/src/components/IdleAlert.tsx
@@ -21,7 +21,7 @@ function IdleAlert(): JSX.Element {
   const { isWalletUnlocked } = useWallet();
   const lockWallet = useLockWallet();
   const isIdle = useIdle(IDLE_TIME_SECONDS * 1000);
-  const isFocused = useWindowFocus();
+  const isFocused = useWindowFocus(IDLE_TIME_SECONDS * 1000);
   const [showModal, setShowModal] = useState(false);
   const [countdown, setCountdown] = useState(IDLE_ALERT_SECONDS);
   const [shouldLockWallet, setShouldLockWallet] = useState(false);

--- a/src/hooks/useWindowFocus.ts
+++ b/src/hooks/useWindowFocus.ts
@@ -1,23 +1,24 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
-function useWindowFocus() {
+function useWindowFocus(timeout = 0) {
   const [focused, setFocused] = useState(true);
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
   useEffect(() => {
     const focusHandler = () => {
-      if (import.meta.env.DEV) {
-        // eslint-disable-next-line no-console
-        console.log('Window is focused');
-        return;
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current);
       }
       setFocused(true);
     };
     const blurHandler = () => {
-      if (import.meta.env.DEV) {
-        // eslint-disable-next-line no-console
-        console.log('Window is blurred');
-        return;
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current);
       }
-      setFocused(false);
+      timeoutRef.current = setTimeout(() => {
+        setFocused(false);
+        timeoutRef.current = null;
+      }, timeout);
     };
     window.addEventListener('focus', focusHandler);
     window.addEventListener('blur', blurHandler);
@@ -25,7 +26,7 @@ function useWindowFocus() {
       window.removeEventListener('focus', focusHandler);
       window.removeEventListener('blur', blurHandler);
     };
-  }, []);
+  }, [timeout]);
 
   return focused;
 }


### PR DESCRIPTION
No issue, but reported few times.

We had two mechanisms:
1. if App is focused, but idle (no mouse move / key press) for 2 minutes — then it shows 30 seconds countdown and then lock the wallet,
2. if App is unfocused then it starts 30 second countdown immediately,

The second mechanism is not convenient, because it locks the wallet even if you just switched tab to copy an address.
So this PR changes the second mechanism to have the same behavior as the first one: it waits for 2 minutes and then starts 30 second countdown.

Also this PR removes inconsistency between production and staging/dev, where second mechanism was turned off.
Now it will work the same in prod and dev.