### PR TITLE
Check account balance before publishing tx

### DIFF
--- a/src/api/schemas/strNumber.ts
+++ b/src/api/schemas/strNumber.ts
@@ -10,6 +10,6 @@ export const BigIntStringSchema = z.custom<string>((a) => {
 });
 
 export const BigIntMin = (min: bigint) =>
-  z.custom<string>((a) => BigInt(a) >= min, {
+  z.custom<string>((a) => a && BigInt(a) >= min, {
     message: `Should be greater than or equal to ${String(min)}`,
   });

--- a/src/components/sendTx/ConfirmationModal.tsx
+++ b/src/components/sendTx/ConfirmationModal.tsx
@@ -77,6 +77,7 @@ type ConfirmationModalProps = ConfirmationData & {
   isOpen: boolean;
   estimatedGas: bigint | null;
   isLedgerRejected?: boolean;
+  insufficientFunds: string;
 };
 
 const renderTemplateSpecificFields = (form: FormValues) => {
@@ -222,6 +223,7 @@ function ConfirmationModal({
   signatures = undefined,
   required = 1,
   isMultiSig = false,
+  insufficientFunds,
   isOpen,
   onClose,
   onSubmit,
@@ -320,7 +322,13 @@ function ConfirmationModal({
     if (!isMultiSig) {
       return (
         <ButtonGroup isAttached>
-          <Button variant="whiteModal" onClick={submit} ml={2} mr="1px">
+          <Button
+            variant="whiteModal"
+            onClick={submit}
+            ml={2}
+            mr="1px"
+            isDisabled={insufficientFunds.length > 0}
+          >
             {hasSingleSig ? 'Publish' : 'Sign & Publish'}
           </Button>
           <Menu>
@@ -349,10 +357,11 @@ function ConfirmationModal({
     return (
       <ButtonGroup isAttached>
         <Button
-          colorScheme="blue"
+          variant="whiteModal"
           onClick={mayPublish ? submit : exportSigned}
           ml={2}
           mr="1px"
+          isDisabled={mayPublish ? insufficientFunds.length > 0 : false}
         >
           {/* eslint-disable-next-line no-nested-ternary */}
           {hasAllSignatures
@@ -365,7 +374,7 @@ function ConfirmationModal({
           <MenuButton
             as={IconButton}
             icon={<IconChevronDown />}
-            colorScheme="blue"
+            variant="whiteModal"
             minW={8}
           />
           <MenuList>
@@ -485,6 +494,11 @@ function ConfirmationModal({
                 />
               )}
             </>
+          )}
+          {!!insufficientFunds && (
+            <Text mt={2} color="brand.red" fontSize="xs">
+              {insufficientFunds}
+            </Text>
           )}
         </ModalBody>
         <ModalFooter


### PR DESCRIPTION
Before allowing to publish transaction it checks for the projected account balance.

<img width="595" alt="image" src="https://github.com/user-attachments/assets/fd718111-53b0-4ab4-993f-48287665ee40">

It checks the sufficient balance for:
- any tx: to pay a gas fee from current account
- spend: to have spend amount + gas fee available
- drain: to have enough funds on vault account (if it is "local" address, otherwise it allows to send a tx)

It also shows a bit different red text on the confirmation page in case if some of the conditions does not pass:
- Waiting for gas estimation...
- You have insufficient funds to pay for gas
- You have insufficient funds to send this amount
- The vault has insufficient funds to be drained