### PR TITLE
Add message signing and verifying

### DIFF
--- a/src/components/EditAccountModal.tsx
+++ b/src/components/EditAccountModal.tsx
@@ -347,7 +347,8 @@ function EditAccountModal({
               isSubmitted={isSubmitted}
             />
             <Text color="orange" my={4} fontSize="xs" textAlign="center">
-              Any changes to the parameters below will alter the account address.
+              Any changes to the parameters below will alter the account
+              address.
               <br />
               Proceed at your own risk.
             </Text>

--- a/src/components/KeyManager.tsx
+++ b/src/components/KeyManager.tsx
@@ -31,6 +31,7 @@ import {
   IconKey,
   IconPlus,
   IconTrash,
+  IconWritingSign,
 } from '@tabler/icons-react';
 
 import useConfirmation from '../hooks/useConfirmation';
@@ -64,6 +65,7 @@ import ImportKeyFromLedgerModal from './ImportKeyFromLedgerModal';
 import ImportKeyPairModal from './ImportKeyPairModal';
 import RenameKeyModal from './RenameKeyModal';
 import RevealSecretKeyModal from './RevealSecretKeyModal';
+import SignMessageModal from './SignMessageModal';
 
 type KeyManagerProps = {
   isOpen: boolean;
@@ -117,9 +119,11 @@ function KeyManager({ isOpen, onClose }: KeyManagerProps): JSX.Element {
   const createAccountModal = useDisclosure();
   const importAccountModal = useDisclosure();
   const editAccountModal = useDisclosure();
+  const signMessageModal = useDisclosure();
 
   const [renameKeyIdx, setRenameKeyIdx] = useState(0);
   const [editAccountIdx, setEditAccountIdx] = useState(0);
+  const [signMessageByKeyIndex, setSignMessageByKeyIndex] = useState(0);
 
   const closeHandler = () => {
     onClose();
@@ -241,59 +245,91 @@ function KeyManager({ isOpen, onClose }: KeyManagerProps): JSX.Element {
                       backgroundColor="blackAlpha.300"
                       borderRadius="md"
                     >
-                      {key.type === KeyPairType.Software ? (
-                        <Button
-                          size="xx-small"
-                          p={1}
-                          fontSize="xx-small"
-                          fontWeight="normal"
-                          float="right"
-                          display="flex"
-                          alignItems="center"
-                          borderRadius="sm"
-                          textTransform="uppercase"
-                          gap={1}
-                          onClick={() => revealSecretKey(key)}
-                          variant="ghostWhite"
-                        >
-                          <IconKey size={12} />
-                          Export secret key
-                        </Button>
-                      ) : (
-                        <Badge
-                          p={1}
-                          fontSize="xx-small"
-                          fontWeight="normal"
-                          float="right"
-                          display="flex"
-                          alignItems="center"
-                          colorScheme="orange"
-                          gap={1}
-                        >
-                          <IconDeviceUsb size={12} />
-                          Hardware
-                        </Badge>
-                      )}
-                      <Text fontWeight="bold" mb={1}>
+                      <Flex
+                        float="right"
+                        flexDir={{ base: 'column', sm: 'row-reverse' }}
+                        alignItems="flex-end"
+                        gap={{ base: 1, sm: 2 }}
+                      >
+                        {key.type === KeyPairType.Software ? (
+                          <>
+                            <Button
+                              size="xx-small"
+                              p={1}
+                              fontSize="xx-small"
+                              fontWeight="normal"
+                              display="flex"
+                              alignItems="center"
+                              borderRadius="sm"
+                              textTransform="uppercase"
+                              gap={1}
+                              onClick={() => revealSecretKey(key)}
+                              variant="ghostWhite"
+                            >
+                              <IconKey size={12} />
+                              Export secret key
+                            </Button>
+                            <Button
+                              size="xx-small"
+                              p={1}
+                              fontSize="xx-small"
+                              fontWeight="normal"
+                              display="flex"
+                              alignItems="center"
+                              borderRadius="sm"
+                              textTransform="uppercase"
+                              gap={1}
+                              onClick={() => {
+                                setSignMessageByKeyIndex(idx);
+                                signMessageModal.onOpen();
+                              }}
+                              variant="ghostWhite"
+                            >
+                              <IconWritingSign size={12} />
+                              Sign message
+                            </Button>
+                          </>
+                        ) : (
+                          <Badge
+                            p={1}
+                            fontSize="xx-small"
+                            fontWeight="normal"
+                            display="flex"
+                            alignItems="center"
+                            colorScheme="orange"
+                            gap={1}
+                          >
+                            <IconDeviceUsb size={12} />
+                            Hardware
+                          </Badge>
+                        )}
+                      </Flex>
+                      <Text as="div" fontWeight="bold" mb={1}>
                         {key.displayName}
-                        <IconButton
-                          ml={2}
-                          aria-label="Rename key"
-                          onClick={() => onRenameKey(idx)}
-                          icon={<IconEdit size={12} />}
-                          variant="whiteOutline"
-                          borderWidth={1}
-                          size="xs"
-                        />
-                        <IconButton
-                          ml={1}
-                          aria-label="Delete key"
-                          onClick={() => onDeleteKey(idx)}
-                          icon={<IconTrash size={12} />}
-                          variant="dangerOutline"
-                          borderWidth={1}
-                          size="xs"
-                        />
+                        <Box
+                          display={{ base: 'block', sm: 'inline-block' }}
+                          ml={{ base: 0, sm: 2 }}
+                          my={{ base: 2, sm: 0 }}
+                        >
+                          <IconButton
+                            aria-label="Rename key"
+                            onClick={() => onRenameKey(idx)}
+                            icon={<IconEdit size={12} />}
+                            variant="whiteOutline"
+                            borderWidth={1}
+                            size="xs"
+                            mr={1}
+                          />
+                          <IconButton
+                            aria-label="Delete key"
+                            onClick={() => onDeleteKey(idx)}
+                            icon={<IconTrash size={12} />}
+                            variant="dangerOutline"
+                            borderWidth={1}
+                            size="xs"
+                            mr={1}
+                          />
+                        </Box>
                       </Text>
 
                       <Text fontSize="xx-small">Public Key</Text>
@@ -482,6 +518,11 @@ function KeyManager({ isOpen, onClose }: KeyManagerProps): JSX.Element {
             accountIndex={editAccountIdx}
             isOpen={editAccountModal.isOpen}
             onClose={editAccountModal.onClose}
+          />
+          <SignMessageModal
+            keyIndex={signMessageByKeyIndex}
+            isOpen={signMessageModal.isOpen}
+            onClose={signMessageModal.onClose}
           />
         </DrawerBody>
       </DrawerContent>

--- a/src/components/MainMenu.tsx
+++ b/src/components/MainMenu.tsx
@@ -16,6 +16,7 @@ import { MAIN_MENU_BUTTONS_SIZE } from '../utils/constants';
 
 import KeyManager from './KeyManager';
 import MnemonicsModal from './MnemonicsModal';
+import VerifyMessageModal from './VerifyMessageModal';
 import WipeOutAlert from './WipeOutAlert';
 
 function MainMenu(): JSX.Element {
@@ -24,6 +25,7 @@ function MainMenu(): JSX.Element {
   const wipeAlert = useDisclosure();
 
   const keyManagerDrawer = useDisclosure();
+  const verifyMessageModal = useDisclosure();
   const { revealMnemonics } = useMnemonics();
   const iconSize = useBreakpointValue(MAIN_MENU_BUTTONS_SIZE, { ssr: false });
 
@@ -46,6 +48,10 @@ function MainMenu(): JSX.Element {
           <MenuItem onClick={revealMnemonics}>Backup mnemonic</MenuItem>
           <MenuItem onClick={exportWalletFile}>Export wallet file</MenuItem>
           <MenuDivider />
+          <MenuItem onClick={verifyMessageModal.onOpen}>
+            Verify Message
+          </MenuItem>
+          <MenuDivider />
           <MenuItem color="red" onClick={wipeAlert.onOpen}>
             Wipe out
           </MenuItem>
@@ -56,6 +62,10 @@ function MainMenu(): JSX.Element {
       <KeyManager
         isOpen={keyManagerDrawer.isOpen}
         onClose={keyManagerDrawer.onClose}
+      />
+      <VerifyMessageModal
+        isOpen={verifyMessageModal.isOpen}
+        onClose={verifyMessageModal.onClose}
       />
     </>
   );

--- a/src/components/SignMessageModal.tsx
+++ b/src/components/SignMessageModal.tsx
@@ -1,0 +1,178 @@
+import fileDownload from 'js-file-download';
+import { useState } from 'react';
+import { useForm } from 'react-hook-form';
+
+import {
+  Button,
+  Modal,
+  ModalBody,
+  ModalCloseButton,
+  ModalContent,
+  ModalFooter,
+  ModalHeader,
+  ModalOverlay,
+  Spacer,
+  Text,
+  Textarea,
+} from '@chakra-ui/react';
+
+import useCopy from '../hooks/useCopy';
+import { useSignMessage } from '../hooks/useSigning';
+import usePassword from '../store/usePassword';
+import useWallet from '../store/useWallet';
+import { SignedMessage } from '../types/message';
+import { KeyPairType } from '../types/wallet';
+import { SIGNED_MESSAGE_PREFIX } from '../utils/constants';
+import { toHexString } from '../utils/hexString';
+
+type SignMessageModalProps = {
+  keyIndex: number;
+  isOpen: boolean;
+  onClose: () => void;
+};
+
+function SignMessageModal({
+  keyIndex,
+  isOpen,
+  onClose,
+}: SignMessageModalProps): JSX.Element | null {
+  const { wallet } = useWallet();
+  const signMessage = useSignMessage();
+  const { withPassword } = usePassword();
+  const { register, reset, handleSubmit } = useForm<{ message: string }>();
+  const [signResult, setSignResult] = useState('');
+  const { isCopied, onCopy } = useCopy();
+
+  const keys = wallet?.keychain ?? [];
+  const key = keys[keyIndex];
+  if (!key) return null;
+
+  const close = () => {
+    setSignResult('');
+    reset();
+    onClose();
+  };
+
+  const download = () =>
+    fileDownload(signResult, `signed-message.json`, 'plain/text');
+
+  const submit = handleSubmit(async ({ message }) => {
+    const result = await withPassword(
+      async (password) => {
+        if (key.type === KeyPairType.Hardware) {
+          // Sign using Ledger device
+          throw new Error('Hardware wallet is not supported yet');
+        }
+        // Sign using local key
+        return JSON.stringify(
+          {
+            publicKey: key.publicKey,
+            text: message,
+            signature: toHexString(
+              await signMessage(
+                `${SIGNED_MESSAGE_PREFIX}${message}`,
+                key.publicKey,
+                password
+              )
+            ),
+          } satisfies SignedMessage,
+          null,
+          2
+        );
+      },
+      'Sign message',
+      <>
+        Please enter your password to sign the message using key &quot;
+        {key.displayName}&quot;{' '}
+        <Text as="span" wordBreak="break-all">
+          ({key.publicKey})
+        </Text>
+      </>
+    );
+    if (result) {
+      setSignResult(result);
+    } else {
+      setSignResult('');
+    }
+  });
+
+  return (
+    <Modal isOpen={isOpen} onClose={close} isCentered>
+      <ModalOverlay />
+      <ModalContent>
+        <ModalCloseButton />
+        <ModalHeader textAlign="center">Sign message</ModalHeader>
+        {signResult ? (
+          <>
+            <ModalBody>
+              <Text mb={4}>
+                Here is your message and the signature. You can copy them to the
+                clipboard and share with another party.
+              </Text>
+              <Textarea
+                readOnly
+                rows={10}
+                resize="none"
+                borderColor="brand.darkGreen"
+                value={signResult}
+                translate="no"
+                fontSize="xx-small"
+              />
+            </ModalBody>
+            <ModalFooter gap={2}>
+              <Button
+                isDisabled={isCopied}
+                onClick={() => onCopy(signResult)}
+                variant="whiteModal"
+                w={20}
+              >
+                {isCopied ? 'Copied' : 'Copy'}
+              </Button>
+              <Button onClick={download} variant="whiteModal">
+                Download
+              </Button>
+              <Spacer />
+              <Button onClick={close} variant="whiteModal">
+                Close
+              </Button>
+            </ModalFooter>
+          </>
+        ) : (
+          <>
+            <ModalBody>
+              <Text mb={4} fontSize="sm">
+                You are going to sign some text message using key &quot;
+                {key.displayName}&quot;{' '}
+                <Text as="span" wordBreak="break-all">
+                  ({key.publicKey})
+                </Text>
+                :
+              </Text>
+              <Textarea
+                {...register('message', {
+                  required: 'Message cannot be empty',
+                })}
+                rows={4}
+                resize="none"
+                borderColor="brand.darkGreen"
+                translate="no"
+              />
+              <Text fontSize="xs" color="gray" mt={2}>
+                The signature will be generated using the private key.
+                <br />
+                Another party may verify the message using your public key.
+              </Text>
+            </ModalBody>
+            <ModalFooter>
+              <Button onClick={submit} ml={2} variant="whiteModal">
+                Sign message...
+              </Button>
+            </ModalFooter>
+          </>
+        )}
+      </ModalContent>
+    </Modal>
+  );
+}
+
+export default SignMessageModal;

--- a/src/components/SignMessageModal.tsx
+++ b/src/components/SignMessageModal.tsx
@@ -63,17 +63,14 @@ function SignMessageModal({
           // Sign using Ledger device
           throw new Error('Hardware wallet is not supported yet');
         }
+        const text = `${SIGNED_MESSAGE_PREFIX}${message}`;
         // Sign using local key
         return JSON.stringify(
           {
             publicKey: key.publicKey,
-            text: message,
+            text,
             signature: toHexString(
-              await signMessage(
-                `${SIGNED_MESSAGE_PREFIX}${message}`,
-                key.publicKey,
-                password
-              )
+              await signMessage(text, key.publicKey, password)
             ),
           } satisfies SignedMessage,
           null,

--- a/src/components/VerifyMessageModal.tsx
+++ b/src/components/VerifyMessageModal.tsx
@@ -1,0 +1,212 @@
+import React, { useRef, useState } from 'react';
+import { Form, useForm } from 'react-hook-form';
+
+import { CheckCircleIcon, WarningIcon } from '@chakra-ui/icons';
+import {
+  Box,
+  Button,
+  Input,
+  Modal,
+  ModalBody,
+  ModalCloseButton,
+  ModalContent,
+  ModalFooter,
+  ModalHeader,
+  ModalOverlay,
+  Text,
+  Textarea,
+} from '@chakra-ui/react';
+
+import { useVerifyMessage } from '../hooks/useSigning';
+import { isSignedMessage } from '../types/message';
+import { SIGNED_MESSAGE_PREFIX } from '../utils/constants';
+
+type VerifyMessageModalProps = {
+  isOpen: boolean;
+  onClose: () => void;
+};
+
+enum VerifyStatus {
+  None = 0,
+  Valid = 1,
+  Invalid = 2,
+}
+
+function VerifyMessageModal({
+  isOpen,
+  onClose,
+}: VerifyMessageModalProps): JSX.Element {
+  const inputRef = useRef<HTMLInputElement>(null);
+  const {
+    setValue,
+    register,
+    reset,
+    setError: setFormError,
+    clearErrors,
+    handleSubmit,
+    formState: { errors },
+    control,
+  } = useForm<{
+    signedMessage: string;
+  }>();
+  const [verifyStatus, setVerifyStatus] = useState(VerifyStatus.None);
+  const verifyMessage = useVerifyMessage();
+
+  const close = () => {
+    setVerifyStatus(VerifyStatus.None);
+    reset();
+    onClose();
+  };
+
+  const setError = (...args: Parameters<typeof setFormError>) => {
+    setVerifyStatus(VerifyStatus.None);
+    setFormError(...args);
+  };
+
+  const submit = handleSubmit(({ signedMessage }) => {
+    const data = (() => {
+      try {
+        return JSON.parse(signedMessage);
+      } catch (err) {
+        setError('root', {
+          type: 'manual',
+          message: `Failed to parse the message:\n${err}`,
+        });
+        return null;
+      }
+    })();
+
+    if (!data) return;
+    if (!isSignedMessage(data)) {
+      setError('root', {
+        type: 'manual',
+        message: 'Invalid signed message format',
+      });
+      return;
+    }
+    verifyMessage(
+      data.signature,
+      `${SIGNED_MESSAGE_PREFIX}${data.text}`,
+      data.publicKey
+    )
+      .then((result) => {
+        setVerifyStatus(result ? VerifyStatus.Valid : VerifyStatus.Invalid);
+      })
+      .catch((err) => {
+        setError('root', {
+          type: 'manual',
+          message: `Failed to verify the signature:\n${err}`,
+        });
+      });
+  });
+
+  const readFile = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+    if (!file) {
+      return;
+    }
+    setValue('signedMessage', '');
+    clearErrors('root');
+
+    const reader = new FileReader();
+    reader.onload = () => {
+      if (typeof reader.result !== 'string') {
+        setError('root', { type: 'manual', message: 'Failed to read file' });
+        return;
+      }
+      try {
+        const msg = JSON.parse(reader.result as string);
+        if (!isSignedMessage(msg)) {
+          setError('root', {
+            type: 'manual',
+            message: 'Invalid signed message file',
+          });
+          return;
+        }
+        setValue('signedMessage', reader.result);
+      } catch (err) {
+        setError('root', {
+          type: 'manual',
+          message: `Failed to open signed message file:\n${err}`,
+        });
+      }
+    };
+    reader.readAsText(file);
+    if (inputRef.current) {
+      // Make it possible to load the same file again
+      inputRef.current.value = '';
+    }
+  };
+
+  return (
+    <Modal isOpen={isOpen} onClose={close} isCentered>
+      <ModalOverlay />
+      <ModalContent>
+        <Form control={control}>
+          <ModalCloseButton />
+          <ModalHeader textAlign="center">Verify Message</ModalHeader>
+          <ModalBody textAlign="center">
+            <Text mb={2} textAlign="center">
+              Please select the signed message file:
+            </Text>
+            <Input
+              ref={inputRef}
+              display="none"
+              type="file"
+              accept=".json"
+              onChange={readFile}
+            />
+            <Button
+              onClick={() => inputRef.current?.click()}
+              variant="whiteModal"
+              mx="auto"
+            >
+              Select the file
+            </Button>
+            <Text my={2}>
+              Or put the signed message object in the text area below:
+            </Text>
+            <Textarea
+              {...register('signedMessage', {
+                required: 'Signed message is required',
+              })}
+              rows={10}
+              resize="none"
+              borderColor="brand.darkGreen"
+              translate="no"
+              fontSize="xx-small"
+            />
+            <Box minH={4} mt={2} textAlign="left">
+              {errors.root?.message && (
+                <Text whiteSpace="pre-wrap" color="brand.red" mb={4}>
+                  <WarningIcon mr={2} mb={1} />
+                  {errors.root.message}
+                </Text>
+              )}
+              {verifyStatus === VerifyStatus.Valid && (
+                <Text whiteSpace="pre-wrap" color="brand.green" mb={4}>
+                  <CheckCircleIcon mr={2} mb={1} />
+                  The signature is valid!
+                </Text>
+              )}
+              {verifyStatus === VerifyStatus.Invalid && (
+                <Text whiteSpace="pre-wrap" color="brand.red" mb={4}>
+                  <WarningIcon mr={2} mb={1} />
+                  The signature is not valid!
+                </Text>
+              )}
+            </Box>
+          </ModalBody>
+
+          <ModalFooter>
+            <Button type="submit" onClick={submit} ml={2} variant="whiteModal">
+              Verify
+            </Button>
+          </ModalFooter>
+        </Form>
+      </ModalContent>
+    </Modal>
+  );
+}
+
+export default VerifyMessageModal;

--- a/src/components/VerifyMessageModal.tsx
+++ b/src/components/VerifyMessageModal.tsx
@@ -84,11 +84,7 @@ function VerifyMessageModal({
       });
       return;
     }
-    verifyMessage(
-      data.signature,
-      `${SIGNED_MESSAGE_PREFIX}${data.text}`,
-      data.publicKey
-    )
+    verifyMessage(data.signature, data.text, data.publicKey)
       .then((result) => {
         setVerifyStatus(result ? VerifyStatus.Valid : VerifyStatus.Invalid);
       })

--- a/src/hooks/useSigning.ts
+++ b/src/hooks/useSigning.ts
@@ -1,0 +1,31 @@
+import { signAsync, verifyAsync } from '@noble/ed25519';
+
+import useWallet from '../store/useWallet';
+import { HexString } from '../types/common';
+
+export const useSignMessage = () => {
+  const { revealSecretKey } = useWallet();
+
+  return async (
+    message: Uint8Array | string,
+    publicKey: HexString,
+    password: string
+  ) => {
+    const data =
+      typeof message === 'string' ? new TextEncoder().encode(message) : message;
+    const secret = await revealSecretKey(publicKey, password);
+    return signAsync(data, secret.slice(0, 64));
+  };
+};
+
+export const useVerifyMessage =
+  () =>
+  async (
+    signature: HexString,
+    message: Uint8Array | string,
+    publicKey: HexString
+  ) => {
+    const data =
+      typeof message === 'string' ? new TextEncoder().encode(message) : message;
+    return verifyAsync(signature, data, publicKey);
+  };

--- a/src/hooks/useTxMethods.ts
+++ b/src/hooks/useTxMethods.ts
@@ -1,12 +1,11 @@
 import { O } from '@mobily/ts-belt';
-import { signAsync } from '@noble/ed25519';
 
 import { fetchEstimatedGas, fetchPublishTx } from '../api/requests/tx';
-import useWallet from '../store/useWallet';
 import { HexString } from '../types/common';
 import { prepareTxForSign } from '../utils/tx';
 
 import { useCurrentGenesisID, useCurrentRPC } from './useNetworkSelectors';
+import { useSignMessage } from './useSigning';
 
 export const useEstimateGas = () => {
   const rpc = useCurrentRPC();
@@ -19,8 +18,8 @@ export const useEstimateGas = () => {
 };
 
 export const useSignTx = () => {
-  const { revealSecretKey } = useWallet();
   const genesisID = useCurrentGenesisID();
+  const sign = useSignMessage();
   return async (
     encodedTx: Uint8Array,
     publicKey: HexString,
@@ -31,11 +30,7 @@ export const useSignTx = () => {
         'Please select the network first and then sign a transaction.'
       );
     }
-    const secret = await revealSecretKey(publicKey, password);
-    return signAsync(
-      prepareTxForSign(genesisID, encodedTx),
-      secret.slice(0, 64)
-    );
+    return sign(prepareTxForSign(genesisID, encodedTx), publicKey, password);
   };
 };
 

--- a/src/types/message.ts
+++ b/src/types/message.ts
@@ -1,0 +1,14 @@
+import { HexString } from './common';
+
+export type SignedMessage = {
+  publicKey: HexString;
+  text: string;
+  signature: HexString;
+};
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export const isSignedMessage = (data: any): data is SignedMessage =>
+  data &&
+  typeof data.publicKey === 'string' &&
+  typeof data.text === 'string' &&
+  typeof data.signature === 'string';

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -59,3 +59,5 @@ export const GENESIS_VESTING_ACCOUNTS = {
 };
 export const GENESIS_VESTING_START = 105120;
 export const GENESIS_VESTING_END = 420480;
+
+export const SIGNED_MESSAGE_PREFIX = 'Message:';


### PR DESCRIPTION
It closes #85.

- adds "Sign message" button next to the every local key in the "Manage Keys & Accounts" pane,
- adds "Verify message" button in the settings dropdown.

This PR does not add support of signing messages by Ledger devices, because it requires some tweaks on Ledger App side.

### Note for third-party developers:
Signature for the message calculated with a hard-coded prefix `Message:` which is encoded as `Uint8Array [77, 101, 115, 115, 97, 103, 101, 58]` to avoid possible vector of attack. So the `verify` function should add this prefix to the message to be able to validate correct signature.

Example:
```
// Message: "Hello, world"
// Signed message: "Message:Hellow, world"
// Signature length is 64 bytes

const te = new TextEncoder();
ed25519.verify(signature, te.encode("Hello, world"), pubKey) // invalid
ed25519.verify(signature, te.encode("Message:Hello, world"), pubKey) // valid
```