### PR TITLE
Display drained amounts next to Drain Transaction

### DIFF
--- a/src/components/TxListItem.tsx
+++ b/src/components/TxListItem.tsx
@@ -2,6 +2,7 @@ import { Box, Card, CardBody, Flex, Icon, Text } from '@chakra-ui/react';
 import { StdMethods } from '@spacemesh/sm-codec';
 import {
   IconArrowBigLeftLinesFilled,
+  IconArrowBigRightLinesFilled,
   IconArrowNarrowDown,
   IconArrowNarrowLeft,
   IconArrowNarrowRight,
@@ -41,8 +42,16 @@ function TxIcon({ tx, host }: { tx: Transaction; host: Bech32Address }) {
             return IconArrowNarrowLeft;
         }
       }
-      case StdMethods.Drain:
-        return IconArrowBigLeftLinesFilled;
+      case StdMethods.Drain: {
+        switch (getTxType(tx, host)) {
+          case TxType.Received:
+          case TxType.Self:
+            return IconArrowBigRightLinesFilled;
+          case TxType.Spent:
+          default:
+            return IconArrowBigLeftLinesFilled;
+        }
+      }
       default:
         return IconQuestionMark;
     }


### PR DESCRIPTION
No issue.

Here are examples, how it looks like:

1. Vault account.
    All drain txs there displayed with the negative sign, because it drains out money from it.
   <img width="572" alt="image" src="https://github.com/user-attachments/assets/a7595848-f367-447a-8792-7b9c9bfc083d">
   
2. Vesting account (which is the owner of the vault).
    Some drain txs there might be marked as "incoming" (with positive green amount), which is actually drained to the same vesting account.
    And some drain txs marked as "outgoing" (with negative red amount), which were drained to some third-party accounts.
    <img width="572" alt="image" src="https://github.com/user-attachments/assets/a5da48cc-01cb-47ac-a06d-279626f28f20">
    
3. Another account, that has incoming drain txs.
    <img width="572" alt="image" src="https://github.com/user-attachments/assets/082c4dbf-e96d-455a-a207-e41a12f2bbbc">
