### PR TITLE
Fix: autoselect account to spawn properly

### DIFF
--- a/src/components/sendTx/SpawnAnotherAccount.tsx
+++ b/src/components/sendTx/SpawnAnotherAccount.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import {
   UseFormRegister,
   UseFormSetValue,
@@ -40,13 +40,29 @@ function SpawnAnotherAccount({
 }: SpawnAnotherAccount) {
   const genesisID = useCurrentGenesisID();
   const { isSpawnedAccount } = useAccountData();
-  const isSpawned = (acc: AccountWithAddress<AnySpawnArguments>) =>
-    pipe(
-      genesisID,
-      O.mapWithDefault(false, (genesis) =>
-        isSpawnedAccount(genesis, acc.address)
-      )
-    );
+  const isSpawned = useCallback(
+    (acc: AccountWithAddress<AnySpawnArguments>) =>
+      pipe(
+        genesisID,
+        O.mapWithDefault(false, (genesis) =>
+          isSpawnedAccount(genesis, acc.address)
+        )
+      ),
+    [genesisID, isSpawnedAccount]
+  );
+
+  useEffect(() => {
+    if (accounts.length > 0) {
+      const firstUnspawned = accounts.find((x) => !isSpawned(x));
+      if (firstUnspawned) {
+        setSelectedAddress(firstUnspawned.address);
+        setValue(
+          'templateAddress',
+          firstUnspawned.templateAddress as StdTemplateKeys
+        );
+      }
+    }
+  }, [accounts, isSpawned, setValue]);
 
   const [selectedAddress, setSelectedAddress] = useState(
     accounts.find((x) => !isSpawned(x))?.address


### PR DESCRIPTION
No issue.

It fixes the problem when User opens Send transaction modal and select "Spawn" method (spawn another account) without further changing of the account to spawn. In that case form get confused about required spawn arguments and works well only if User selects another account (or another account and then select back the account chosen by default).

This PR fixes that and now form works well from the beginning.